### PR TITLE
fix(task): 强制管理端任务操作鉴权，修复任务劫持漏洞

### DIFF
--- a/service/identity.go
+++ b/service/identity.go
@@ -49,6 +49,24 @@ func IsSystemActor(a *Actor) bool {
 	return a != nil && a.UserID == constants.UserSystem
 }
 
+// requireAdminIdentity 校验操作人为工作流管理员（Actor.SuperAdmin）或系统身份。
+// 用于跳过 assignee/候选人校验的强制改派类管理操作（Reassign/SetAssignee/SetOwner）：
+// 这些操作绕过"仅本人可操作"语义，引擎内部无其他鉴权点，必须在入口强制校验，
+// 否则任意同租户用户可拿到 taskID 即劫持他人任务。
+//
+// 系统身份（IsSystemActor）放行，供定时巡检/跨服务级联等引擎内部机制使用；
+// 管理员身份由宿主服务端按角色判定后置 SuperAdmin 标记（Actor 无 json tag，
+// 不能从请求体反序列化伪造）。
+func requireAdminIdentity(actor *Actor) error {
+	if actor == nil || actor.UserID == "" {
+		return fmt.Errorf("admin identity required: %w", ErrAuthenticationRequired)
+	}
+	if actor.SuperAdmin || IsSystemActor(actor) {
+		return nil
+	}
+	return fmt.Errorf("operation requires admin or system identity: %w", ErrPermissionDenied)
+}
+
 // ActorFromCtx 取 ctx 已绑定操作人，未绑定返回 SystemActor。
 // 供引擎内部回调（aspect/节点/级联）使用，保留原身份可维持租户校验与事件归属。
 func ActorFromCtx(ctx context.Context) Actor {

--- a/service/task_service.go
+++ b/service/task_service.go
@@ -68,10 +68,12 @@ type TaskService interface {
 	// 委派中的任务（有 Owner）会归还给原审批人而非扔回候选池。
 	Unclaim(ctx context.Context, actor Actor, taskID string) error
 
-	// SetAssignee 设置任务分配人
+	// SetAssignee 设置任务分配人。管理操作：须管理员（SuperAdmin）或系统身份，
+	// 普通用户无权调用（否则可劫持他人任务或解除分配使任务回池）。
 	SetAssignee(ctx context.Context, actor Actor, taskID, userID string) error
 
-	// SetOwner 设置任务所有者
+	// SetOwner 设置任务所有者。管理操作：须管理员（SuperAdmin）或系统身份，
+	// Owner 驱动委派归还路径，普通用户无权改写。
 	SetOwner(ctx context.Context, actor Actor, taskID, userID string) error
 
 	// Delegate 委派任务给其他用户：assignee 转为目标用户，原 assignee 记为 Owner。
@@ -79,7 +81,8 @@ type TaskService interface {
 	// 不会直接完成流转。设计器显式禁用 delegate 时拒绝。
 	Delegate(ctx context.Context, actor Actor, taskID, userID, reason string) error
 
-	// Resolve 解决委派的任务（委派任务完成后返回给原分配人）
+	// Resolve 解决委派的任务（委派任务完成后返回给原分配人）。仅被委派人（assignee）、
+	// 原办理人（Owner）或管理员/系统身份可调用。
 	Resolve(ctx context.Context, actor Actor, taskID string) error
 
 	// GetHistoryTasksByProcessInstanceID 获取实例的全部已归档任务（wf_hi_task）

--- a/service/task_service_assignment.go
+++ b/service/task_service_assignment.go
@@ -9,15 +9,21 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/rulego/gflow-engine/model"
 	"github.com/rulego/gflow-engine/types/enums"
 	utils2 "github.com/rulego/gflow-engine/utils"
 )
 
-// SetAssignee 设置任务分配人
+// SetAssignee 设置任务分配人。
+// 强制改派任意任务的办理人，与 Reassign 同属管理操作：必须管理员（SuperAdmin）
+// 或系统身份，普通用户无权调用（否则可劫持他人任务或解除分配使任务回池）。
 func (s *TaskServiceImpl) SetAssignee(ctx context.Context, actor Actor, taskID, userID string) error {
 	ctx = bindActor(ctx, actor)
 	if taskID == "" {
 		return fmt.Errorf("task ID cannot be empty")
+	}
+	if err := requireAdminIdentity(&actor); err != nil {
+		return err
 	}
 
 	task, err := s.taskDAO.Get(ctx, taskID)
@@ -79,11 +85,16 @@ func (s *TaskServiceImpl) setAssigneeInternal(ctx context.Context, scope *Instan
 	return nil
 }
 
-// SetOwner 设置任务所有者
+// SetOwner 设置任务所有者。
+// Owner 驱动委派归还路径，篡改即改写审批走向，属管理操作：必须管理员（SuperAdmin）
+// 或系统身份。
 func (s *TaskServiceImpl) SetOwner(ctx context.Context, actor Actor, taskID, userID string) error {
 	ctx = bindActor(ctx, actor)
 	if taskID == "" {
 		return fmt.Errorf("task ID cannot be empty")
+	}
+	if err := requireAdminIdentity(&actor); err != nil {
+		return err
 	}
 
 	task, err := s.taskDAO.Get(ctx, taskID)
@@ -301,6 +312,26 @@ func (s *TaskServiceImpl) Resolve(ctx context.Context, actor Actor, taskID strin
 	})
 }
 
+// authorizeResolveOperator 校验委派归还（Resolve）的操作人：须为任务当前办理人
+// （被委派人 assignee）、原办理人（owner）或管理员/系统身份。由 resolveInternal 在
+// 实例行锁内读的最新任务快照上执行，避免锁外读被并发改派绕过的 TOCTOU 窗口。
+func (s *TaskServiceImpl) authorizeResolveOperator(ctx context.Context, task *model.WfTask) error {
+	u := GetUserFromCtx(ctx)
+	if u == nil || u.UserID == "" {
+		return ErrAuthenticationRequired
+	}
+	if u.SuperAdmin || IsSystemActor(u) {
+		return nil
+	}
+	if task.Assignee != nil && *task.Assignee == u.UserID {
+		return nil
+	}
+	if task.Owner != nil && *task.Owner == u.UserID {
+		return nil
+	}
+	return fmt.Errorf("user %s is neither delegatee nor owner of task %s: %w", u.UserID, task.ID, ErrPermissionDenied)
+}
+
 func (s *TaskServiceImpl) resolveInternal(ctx context.Context, scope *InstanceScope, taskID string) error {
 	taskDAO := scope.Tasks()
 	task, err := taskDAO.Get(ctx, taskID)
@@ -309,6 +340,11 @@ func (s *TaskServiceImpl) resolveInternal(ctx context.Context, scope *InstanceSc
 	}
 	if task == nil {
 		return fmt.Errorf("%w: task", ErrNotFound)
+	}
+
+	// 鉴权：仅被委派人（assignee）、原办理人（owner）或管理员/系统身份可归还。
+	if err := s.authorizeResolveOperator(ctx, task); err != nil {
+		return err
 	}
 
 	// 幂等：已经没有 Owner（说明已 resolve 过）

--- a/service/task_service_assignment_test.go
+++ b/service/task_service_assignment_test.go
@@ -75,3 +75,67 @@ func TestSecFix_TransferCrossTenantRejected(t *testing.T) {
 	require.Error(t, err, "跨租户转办必须拒绝")
 	require.True(t, errors.Is(err, ErrNotFound), "跨租户应伪装成 not found，got %v", err)
 }
+
+func TestSecFix_SetAssigneeRequiresAdmin(t *testing.T) {
+	q := secFixDB(t)
+	ctx := context.Background()
+	require.NoError(t, q.WfTask.Create(&model.WfTask{
+		ID: "task-sa", TaskDefKey: "approve", Name: "审批", TaskType: "user_task",
+		Status: string(enums.TaskStatusActive), Assignee: secFixStrPtr("userA"),
+		TenantID: "t1", CreatedBy: "system", CreatedAt: time.Now(),
+	}))
+	taskSvc := &TaskServiceImpl{taskDAO: dao.NewTaskDAOWithQuery(q), workflowEngine: &testEngineDouble{}}
+
+	// 普通同租户用户非管理员 → 拒绝（改派他人任务是管理操作）
+	err := taskSvc.SetAssignee(ctx, Actor{UserID: "userB", TenantID: "t1"}, "task-sa", "userC")
+	require.Error(t, err)
+	require.True(t, errors.Is(err, ErrPermissionDenied), "期望 ErrPermissionDenied，got %v", err)
+
+	// 空身份 → 拒绝
+	require.Error(t, taskSvc.SetAssignee(ctx, Actor{TenantID: "t1"}, "task-sa", "userC"))
+
+	// 管理员 → 放行
+	require.NoError(t, taskSvc.SetAssignee(ctx, Actor{UserID: "admin1", TenantID: "t1", SuperAdmin: true}, "task-sa", "userC"))
+	persisted, err := taskSvc.taskDAO.Get(ctx, "task-sa")
+	require.NoError(t, err)
+	require.Equal(t, "userC", *persisted.Assignee)
+}
+
+func TestSecFix_SetOwnerRequiresAdmin(t *testing.T) {
+	q := secFixDB(t)
+	ctx := context.Background()
+	require.NoError(t, q.WfTask.Create(&model.WfTask{
+		ID: "task-so", TaskDefKey: "approve", Name: "审批", TaskType: "user_task",
+		Status: string(enums.TaskStatusActive), Assignee: secFixStrPtr("userA"),
+		TenantID: "t1", CreatedBy: "system", CreatedAt: time.Now(),
+	}))
+	taskSvc := &TaskServiceImpl{taskDAO: dao.NewTaskDAOWithQuery(q), workflowEngine: &testEngineDouble{}}
+
+	// 普通同租户用户 → 拒绝
+	err := taskSvc.SetOwner(ctx, Actor{UserID: "userB", TenantID: "t1"}, "task-so", "userB")
+	require.Error(t, err)
+	require.True(t, errors.Is(err, ErrPermissionDenied), "期望 ErrPermissionDenied，got %v", err)
+
+	// 管理员 → 放行
+	require.NoError(t, taskSvc.SetOwner(ctx, Actor{UserID: "admin1", TenantID: "t1", SuperAdmin: true}, "task-so", "userB"))
+}
+
+func TestSecFix_ResolveRequiresOperator(t *testing.T) {
+	q := secFixDB(t)
+	ctx := context.Background()
+	owner, delegatee := "owner-1", "delegatee-1"
+	require.NoError(t, q.WfTask.Create(&model.WfTask{
+		ID: "task-rs", TaskDefKey: "approve", Name: "审批", TaskType: "user_task",
+		Status: string(enums.TaskStatusActive), Assignee: &delegatee, Owner: &owner,
+		TenantID: "t1", CreatedBy: "system", CreatedAt: time.Now(),
+	}))
+	taskSvc := &TaskServiceImpl{taskDAO: dao.NewTaskDAOWithQuery(q), workflowEngine: &testEngineDouble{}}
+
+	// 无关同租户用户 → 拒绝（既非被委派人、非原办理人、也非管理员）
+	err := taskSvc.Resolve(ctx, Actor{UserID: "intruder", TenantID: "t1"}, "task-rs")
+	require.Error(t, err)
+	require.True(t, errors.Is(err, ErrPermissionDenied), "期望 ErrPermissionDenied，got %v", err)
+
+	// 原办理人（owner）→ 放行
+	require.NoError(t, taskSvc.Resolve(ctx, Actor{UserID: owner, TenantID: "t1"}, "task-rs"))
+}

--- a/service/task_service_reassign.go
+++ b/service/task_service_reassign.go
@@ -30,6 +30,12 @@ func (s *TaskServiceImpl) Reassign(ctx context.Context, actor Actor, taskID, new
 		return "", fmt.Errorf("new assignee cannot be empty: %w", ErrValidation)
 	}
 
+	// 管理操作鉴权：Reassign 跳过 assignee/候选人校验，必须管理员（SuperAdmin）或系统身份，
+	// 否则任意同租户用户可强改派任意任务（任务劫持）。
+	if err := requireAdminIdentity(&actor); err != nil {
+		return "", err
+	}
+
 	// 廉价读：解析 instanceID 并做租户校验，无锁
 	task, err := s.taskDAO.Get(ctx, taskID)
 	if err != nil {

--- a/service/task_service_reassign_test.go
+++ b/service/task_service_reassign_test.go
@@ -209,7 +209,7 @@ func TestReassignTask_EndToEnd(t *testing.T) {
 	}
 	svc := &TaskServiceImpl{taskDAO: d, workflowEngine: &reassignListenerEngine{listener: listener}}
 
-	old, err := svc.Reassign(ctx, Actor{UserID: "admin1", TenantID: "t1"}, "task-e2e", "userB", "负载调整")
+	old, err := svc.Reassign(ctx, Actor{UserID: "admin1", TenantID: "t1", SuperAdmin: true}, "task-e2e", "userB", "负载调整")
 	require.NoError(t, err)
 	require.Equal(t, "userA", old)
 
@@ -250,7 +250,24 @@ func TestReassignTask_EndToEnd_RejectsNonActive(t *testing.T) {
 		CreatedAt: now, CreatedBy: "system",
 	}))
 	svc := &TaskServiceImpl{taskDAO: d, workflowEngine: &reassignListenerEngine{}}
-	_, err := svc.Reassign(ctx, Actor{UserID: "admin1", TenantID: "t1"}, "task-done", "userB", "")
+	_, err := svc.Reassign(ctx, Actor{UserID: "admin1", TenantID: "t1", SuperAdmin: true}, "task-done", "userB", "")
 	require.Error(t, err)
 	require.True(t, errors.Is(err, ErrValidation))
+}
+
+// TestReassignTask_NonAdminDenied 验证：普通同租户用户（无 SuperAdmin，也非系统身份）改派被拒绝。
+// 鉴权在 DB 读之前执行，故无需建表。
+func TestReassignTask_NonAdminDenied(t *testing.T) {
+	svc := &TaskServiceImpl{}
+	_, err := svc.Reassign(context.Background(), Actor{UserID: "userB", TenantID: "t1"}, "task-1", "userC", "reason")
+	require.Error(t, err)
+	require.True(t, errors.Is(err, ErrPermissionDenied), "非管理员改派必须拒绝，got %v", err)
+}
+
+// TestReassignTask_EmptyOperatorDenied 验证：空操作人身份（无 UserID）改派被拒绝。
+func TestReassignTask_EmptyOperatorDenied(t *testing.T) {
+	svc := &TaskServiceImpl{}
+	_, err := svc.Reassign(context.Background(), Actor{TenantID: "t1"}, "task-1", "userC", "reason")
+	require.Error(t, err)
+	require.True(t, errors.Is(err, ErrAuthenticationRequired), "空身份改派必须拒绝，got %v", err)
 }


### PR DESCRIPTION
🤖 人工智能辅助贡献  
使用的工具：Deepseek Harness / deepseek v4 pro
参与程度：所有变更部分。所有代码均已人工审核并通过验证。

## 背景

安全审查发现以下方法仅有租户比对、缺乏操作人鉴权，任意同租户用户只要拿到 `taskID`
即可劫持他人任务或改写审批走向：

- `Reassign`：管理员强制改派，但入口没有管理员/系统身份校验，普通用户可强改派任意任务；
- `SetAssignee`：可把任意任务改派给他人或清空分配（使任务回池）；
- `SetOwner`：`Owner` 驱动委派归还路径，篡改即改写审批走向；
- `Resolve`：委派归还，完全没有任何操作人校验，任意同租户用户可触发委派归还。

## 改动

- 新增 `requireAdminIdentity(actor)`（`service/identity.go`）：要求 `SuperAdmin`
  或系统身份；同时拒绝空 `UserID`（审计字段与事件 FromUser 不能为空）。
- `Reassign` / `SetAssignee` / `SetOwner` 在 DB 读之前强制走 `requireAdminIdentity`，
  非管理员在访问任务前即被拒绝，不泄漏任务存在性。
- `resolveInternal` 内新增 `authorizeResolveOperator`，在**实例行锁内读的最新任务
  快照**上校验：仅被委派人（assignee）、原办理人（owner）或管理员/系统身份可归还，
  收窄锁外读的 TOCTOU 绕过窗口。
- 同步更新接口与实现注释，明确各方法的鉴权语义。

## 破坏性变更

- 调用方必须给 `Reassign` / `SetAssignee` / `SetOwner` 传入带 `SuperAdmin: true`
  的 `Actor`（或系统身份），否则返回 `ErrPermissionDenied`。
- `Resolve` 仅被委派人、原办理人或管理员/系统身份可调用，其余返回 `ErrPermissionDenied`。
- `SuperAdmin` 仍由宿主服务端按角色判定后显式置位（`Actor` 无 json tag，无法从请求体反序列化伪造）。

## 测试

- 新增：非管理员 Reassign/SetAssignee/SetOwner 被拒绝、空身份被拒绝、Resolve 归属校验
  （assignee/owner 放行、无关用户拒绝）。
- 修正原 Reassign 端到端用例为 `SuperAdmin: true`。

## 验证

- `gofmt` 干净
- `go vet ./...` 通过
- `go build ./...` 通过
- `go test ./...`（含 e2e）全绿