### PR TITLE
fix(task): 补齐 Return/Unclaim/Delegate/AddSign 的租户隔离

### DIFF
--- a/service/task_service_assignment.go
+++ b/service/task_service_assignment.go
@@ -159,6 +159,13 @@ func (s *TaskServiceImpl) Delegate(ctx context.Context, actor Actor, taskID, use
 		return err
 	}
 
+	// 目标用户租户归属校验（IdentityService 实现 TenantMembershipChecker 时生效）。
+	// 转办/改派已校验目标租户，委派此前漏查——否则可把任务委派给其他租户用户，
+	// 导致跨租户任务被他人处理（审批越权）。
+	if err := s.ensureTargetUserInTenant(ctx, task, userID, "delegate"); err != nil {
+		return err
+	}
+
 	// 设计器显式禁用 delegate → 拒绝（actionPermissions 解析失败时降级放行）
 	if err := s.requireActionEnabled(ctx, task, "delegate"); err != nil {
 		return err

--- a/service/task_service_claim.go
+++ b/service/task_service_claim.go
@@ -231,6 +231,12 @@ func (s *TaskServiceImpl) unclaimInternal(ctx context.Context, scope *InstanceSc
 		return fmt.Errorf("%w: task", ErrNotFound)
 	}
 
+	// 租户隔离：取消认领与认领（claimInternal）同口径，跨租户按 not found 隐藏，
+	// 不泄露任务存在性。此前 Unclaim 漏校验，其他租户用户可通过 taskID 取消他人认领。
+	if u := GetUserFromCtx(ctx); u != nil && task.TenantID != u.TenantID {
+		return fmt.Errorf("%w: task", ErrNotFound)
+	}
+
 	// 幂等：已经是 Pending 且无人认领
 	if task.Status == string(enums.TaskStatusPending) && (task.Assignee == nil || *task.Assignee == "") {
 		return nil

--- a/service/task_service_sign.go
+++ b/service/task_service_sign.go
@@ -67,6 +67,14 @@ func (s *TaskServiceImpl) AddSign(ctx context.Context, actor Actor, taskID strin
 		return err
 	}
 
+	// 被加签人租户归属校验（IdentityService 实现 TenantMembershipChecker 时生效）。
+	// 此前漏校验：可把加签任务指派给其他租户用户，导致跨租户用户参与审批。
+	for _, uid := range userIDs {
+		if err := s.ensureTargetUserInTenant(ctx, task, uid, "addSign"); err != nil {
+			return err
+		}
+	}
+
 	// 设计器显式禁用 addSign → 拒绝（actionPermissions 解析失败时降级放行）
 	if err := s.requireActionEnabled(ctx, task, "addSign"); err != nil {
 		return err

--- a/service/task_service_tenant_isolation_test.go
+++ b/service/task_service_tenant_isolation_test.go
@@ -1,0 +1,92 @@
+package service
+
+// PR2 租户隔离补齐用例：
+// Return / Unclaim 跨租户按 not found 隐藏；
+// Delegate / AddSign 的目标用户跨租户按 PermissionDenied 拒绝。
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/rulego/gflow-engine/dao"
+	"github.com/rulego/gflow-engine/model"
+	"github.com/rulego/gflow-engine/types/enums"
+)
+
+// tenantCheckingIdentity 在 IdentityService 之上叠加 TenantMembershipChecker，
+// IsUserInTenant 由 membership map 驱动。本组用例只走 IsUserInTenant（委派/加签
+// 目标租户校验），其余 IdentityService 方法不会被调用。
+type tenantCheckingIdentity struct {
+	IdentityService
+	membership map[string]bool
+}
+
+func (m *tenantCheckingIdentity) IsUserInTenant(_ context.Context, tenantID, userID string) (bool, error) {
+	return m.membership[userID], nil
+}
+
+func TestSecFix_ReturnCrossTenantRejected(t *testing.T) {
+	q := candGroupDB(t)
+	ctx := context.Background()
+	require.NoError(t, q.WfTask.Create(&model.WfTask{
+		ID: "task-ret-xt", TaskDefKey: "approve", Name: "审批", TaskType: "user_task",
+		Status: string(enums.TaskStatusActive), Assignee: secFixStrPtr("userA"),
+		TenantID: "t1", CreatedBy: "system", CreatedAt: time.Now(),
+	}))
+	taskSvc := &TaskServiceImpl{taskDAO: dao.NewTaskDAOWithQuery(q), workflowEngine: candGroupEngine{}}
+
+	err := taskSvc.Return(ctx, Actor{UserID: "userB", TenantID: "t2"}, "task-ret-xt", "node1", "reason")
+	require.Error(t, err)
+	require.True(t, errors.Is(err, ErrNotFound), "跨租户 Return 应伪装成 not found，got %v", err)
+}
+
+func TestSecFix_UnclaimCrossTenantRejected(t *testing.T) {
+	q := candGroupDB(t)
+	ctx := context.Background()
+	require.NoError(t, q.WfTask.Create(&model.WfTask{
+		ID: "task-unclaim-xt", TaskDefKey: "approve", Name: "审批", TaskType: "user_task",
+		Status: string(enums.TaskStatusActive), Assignee: secFixStrPtr("userA"),
+		TenantID: "t1", CreatedBy: "system", CreatedAt: time.Now(),
+	}))
+	taskSvc := &TaskServiceImpl{taskDAO: dao.NewTaskDAOWithQuery(q), workflowEngine: candGroupEngine{}}
+
+	err := taskSvc.Unclaim(ctx, Actor{UserID: "userB", TenantID: "t2"}, "task-unclaim-xt")
+	require.Error(t, err)
+	require.True(t, errors.Is(err, ErrNotFound), "跨租户 Unclaim 应伪装成 not found，got %v", err)
+}
+
+func TestSecFix_DelegateTargetCrossTenantRejected(t *testing.T) {
+	q := candGroupDB(t)
+	ctx := context.Background()
+	require.NoError(t, q.WfTask.Create(&model.WfTask{
+		ID: "task-del-xt", TaskDefKey: "approve", Name: "审批", TaskType: "user_task",
+		Status: string(enums.TaskStatusActive), Assignee: secFixStrPtr("userA"),
+		TenantID: "t1", CreatedBy: "system", CreatedAt: time.Now(),
+	}))
+	ident := &tenantCheckingIdentity{membership: map[string]bool{"userA": true, "userB": false}}
+	taskSvc := &TaskServiceImpl{taskDAO: dao.NewTaskDAOWithQuery(q), workflowEngine: candGroupEngine{identity: ident}}
+
+	err := taskSvc.Delegate(ctx, Actor{UserID: "userA", TenantID: "t1"}, "task-del-xt", "userB", "reason")
+	require.Error(t, err)
+	require.True(t, errors.Is(err, ErrPermissionDenied), "跨租户委派目标应拒绝，got %v", err)
+}
+
+func TestSecFix_AddSignTargetCrossTenantRejected(t *testing.T) {
+	q := candGroupDB(t)
+	ctx := context.Background()
+	require.NoError(t, q.WfTask.Create(&model.WfTask{
+		ID: "task-addsign-xt", TaskDefKey: "approve", Name: "审批", TaskType: "user_task",
+		Status: string(enums.TaskStatusActive), Assignee: secFixStrPtr("userA"),
+		TenantID: "t1", CreatedBy: "system", CreatedAt: time.Now(),
+	}))
+	ident := &tenantCheckingIdentity{membership: map[string]bool{"userA": true, "userB": false}}
+	taskSvc := &TaskServiceImpl{taskDAO: dao.NewTaskDAOWithQuery(q), workflowEngine: candGroupEngine{identity: ident}}
+
+	err := taskSvc.AddSign(ctx, Actor{UserID: "userA", TenantID: "t1"}, "task-addsign-xt", []string{"userB"}, "reason")
+	require.Error(t, err)
+	require.True(t, errors.Is(err, ErrPermissionDenied), "跨租户加签目标应拒绝，got %v", err)
+}

--- a/service/task_service_withdraw.go
+++ b/service/task_service_withdraw.go
@@ -269,6 +269,13 @@ func (s *TaskServiceImpl) Return(ctx context.Context, actor Actor, taskID, targe
 		return fmt.Errorf("%w: task", ErrNotFound)
 	}
 
+	// 租户隔离：跨租户任务按 not found 隐藏（对齐 Withdraw/Claim 口径）。
+	// Return 此前漏校验任务租户，其他租户用户拿到 taskID+targetActivityID 即可
+	// 把他人租户的任务退回到指定节点。
+	if u := GetUserFromCtx(ctx); u != nil && task.TenantID != u.TenantID {
+		return fmt.Errorf("%w: task", ErrNotFound)
+	}
+
 	// 设计器显式禁用 return → 拒绝（actionPermissions 解析失败时降级放行）
 	if err := s.requireActionEnabled(ctx, task, "return"); err != nil {
 		return err


### PR DESCRIPTION
🤖 人工智能辅助贡献  
使用的工具：Deepseek Harness / deepseek v4 pro
参与程度：全部变更代码。所有代码均已人工审核并通过验证。

## 背景

安全审查发现 4 个变更操作存在租户隔离缺口，可被同平台其他租户用户越权操作：

- `Return`：完全没有任务租户校验，拿到 `taskID + targetActivityID` 即可把他人租户任务退回指定节点；
- `Unclaim`：缺少 `claimInternal` 早已具备的租户校验，跨租户用户可用 `taskID` 取消他人签收（释放任务）；
- `Delegate`：未校验委派目标用户租户，可把任务委派给其他租户用户处理；
- `AddSign`：未校验被加签人租户，可向其他租户用户派发加签审批任务。

## 改动

- `Return`：跨租户任务按 `ErrNotFound` 隐藏（对齐 Withdraw/Claim 口径，不泄露任务存在性）。
- `Unclaim`：在 `unclaimInternal` 内补同口径 `ErrNotFound` 租户门禁。
- `Delegate`：调用 `ensureTargetUserInTenant` 校验目标用户租户（与 Transfer/Reassign 对齐）。
- `AddSign`：对每个被加签人逐一执行 `ensureTargetUserInTenant`。

委派/加签的目标租户校验仅在宿主 `IdentityService` 同时实现 `TenantMembershipChecker`
可选接口时生效；未实现时按既有 SPI 约定跳过，其余行为保持不变。

## 测试

新增 `service/task_service_tenant_isolation_test.go`，覆盖上述四条路径的跨租户拒绝
（`tenantCheckingIdentity` 测试替身叠加 `TenantMembershipChecker` 驱动 `IsUserInTenant`）。

## 验证

- `gofmt` / `go vet ./service/...` / `go build ./...` / `go test ./...`（含 e2e）全部通过。