### PR TITLE
fix(task): 系统 DeleteTask 走实例行锁，堵住锁绕过并发竞争

### DIFF
--- a/service/task_service_crud.go
+++ b/service/task_service_crud.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/rulego/gflow-engine/model"
-	"github.com/rulego/gflow-engine/types/constants"
 	"github.com/rulego/gflow-engine/types/dto"
 	"github.com/rulego/gflow-engine/types/enums"
 )
@@ -125,35 +124,35 @@ func (s *TaskServiceImpl) DeleteTask(ctx context.Context, actor Actor, taskID, r
 	}
 
 	// 权限校验：操作人以显式参数 userID 为准。
-	// 系统身份（引擎内部回滚/清理路径，如候选写入失败删任务）免用户级校验。
-	if userID == constants.UserSystem {
-		if err := s.taskDAO.Delete(ctx, taskID); err != nil {
-			return fmt.Errorf("failed to delete task: %w", err)
+	// 系统身份（引擎内部回滚/清理路径，如候选写入失败删任务）免用户级校验，
+	// 但仍走下方同一条持锁删除路径（WithInstanceTx），与普通删除一致地串行化。
+	// 此前系统分支用字符串比对后直接 taskDAO.Delete，绕过实例行锁——与并发
+	// Complete 竞争会留下重复终止态记录或丢失审批历史（本方法顶部注释描述的问题）。
+	isSystem := IsSystemActor(&actor)
+	if !isSystem {
+		// 租户校验：ctx 带身份时任务必须同租户（防跨租户删除）
+		if u := GetUserFromCtx(ctx); u != nil && task.TenantID != u.TenantID {
+			return fmt.Errorf("%w: task", ErrNotFound)
 		}
-		return nil
-	}
-	// 租户校验：ctx 带身份时任务必须同租户（防跨租户删除）
-	if u := GetUserFromCtx(ctx); u != nil && task.TenantID != u.TenantID {
-		return fmt.Errorf("%w: task", ErrNotFound)
-	}
-	isSuperAdmin := false
-	if u := GetUserFromCtx(ctx); u != nil {
-		isSuperAdmin = u.SuperAdmin
-	}
-	if task.Assignee != nil && *task.Assignee != "" {
-		// 已分配的任务：只有 assignee 可以删除
-		if *task.Assignee != userID {
-			return fmt.Errorf("task assigned to %s, operator %s: %w", *task.Assignee, userID, ErrPermissionDenied)
+		isSuperAdmin := false
+		if u := GetUserFromCtx(ctx); u != nil {
+			isSuperAdmin = u.SuperAdmin
 		}
-	} else if task.ProcessInstanceID != nil && *task.ProcessInstanceID != "" {
-		// 未分配的任务：只有流程发起人或管理员可以删除。
-		// 查不到实例（含查询失败）一律拒绝——放行会删掉无法溯源的任务。
-		instance, err := s.workflowEngine.GetRuntimeService().GetProcessInstance(ctx, ActorFromCtx(ctx), *task.ProcessInstanceID)
-		if err != nil || instance == nil {
-			return fmt.Errorf("cannot verify instance initiator, refuse to delete: %w", ErrPermissionDenied)
-		}
-		if instance.StartUserID != userID && !isSuperAdmin {
-			return fmt.Errorf("only the process initiator or admin can delete unassigned tasks: %w", ErrPermissionDenied)
+		if task.Assignee != nil && *task.Assignee != "" {
+			// 已分配的任务：只有 assignee 可以删除
+			if *task.Assignee != userID {
+				return fmt.Errorf("task assigned to %s, operator %s: %w", *task.Assignee, userID, ErrPermissionDenied)
+			}
+		} else if task.ProcessInstanceID != nil && *task.ProcessInstanceID != "" {
+			// 未分配的任务：只有流程发起人或管理员可以删除。
+			// 查不到实例（含查询失败）一律拒绝——放行会删掉无法溯源的任务。
+			instance, err := s.workflowEngine.GetRuntimeService().GetProcessInstance(ctx, ActorFromCtx(ctx), *task.ProcessInstanceID)
+			if err != nil || instance == nil {
+				return fmt.Errorf("cannot verify instance initiator, refuse to delete: %w", ErrPermissionDenied)
+			}
+			if instance.StartUserID != userID && !isSuperAdmin {
+				return fmt.Errorf("only the process initiator or admin can delete unassigned tasks: %w", ErrPermissionDenied)
+			}
 		}
 	}
 

--- a/service/task_service_crud_system_delete_test.go
+++ b/service/task_service_crud_system_delete_test.go
@@ -1,0 +1,72 @@
+package service
+
+// PR4 用例：DeleteTask 的系统身份分支不再绕过实例行锁。
+// 此前系统分支用 userID=="system" 字符串比对后直接 taskDAO.Delete，跳过
+// WithInstanceTx——系统侧直删与并发 Complete 竞争会留下重复终止态或丢审批历史。
+// 修复后系统身份应与普通删除走同一条持锁路径：active 实例可删、终态实例拒绝。
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/rulego/gflow-engine/dao"
+	"github.com/rulego/gflow-engine/model"
+	"github.com/rulego/gflow-engine/types/enums"
+)
+
+// TestSecFix_SystemDeleteActiveInstance 系统身份删除 active 实例上的任务应成功（走锁 + 删除）。
+func TestSecFix_SystemDeleteActiveInstance(t *testing.T) {
+	q := candGroupDB(t)
+	ctx := context.Background()
+	now := time.Now()
+
+	require.NoError(t, q.WfInstance.Create(&model.WfInstance{
+		ID: "inst-sys-active", ProcessID: "p1", Name: "sys_del_active",
+		Status: string(enums.InstanceStatusActive), StartUserID: "starter",
+		TenantID: "t1", CreatedBy: "starter", CreatedAt: now,
+	}))
+	require.NoError(t, q.WfTask.Create(&model.WfTask{
+		ID: "task-sys-active", ProcessInstanceID: secFixStrPtr("inst-sys-active"), TaskDefKey: "approve",
+		Name: "审批", TaskType: "user_task", Status: string(enums.TaskStatusActive),
+		Assignee: secFixStrPtr("userA"), TenantID: "t1", CreatedBy: "system", CreatedAt: now,
+	}))
+
+	taskSvc := &TaskServiceImpl{taskDAO: dao.NewTaskDAOWithQuery(q), workflowEngine: &testEngineDouble{}}
+	require.NoError(t, taskSvc.DeleteTask(ctx, SystemActor(), "task-sys-active", "cleanup"))
+
+	count, cerr := q.WfTask.WithContext(ctx).Where(q.WfTask.ID.Eq("task-sys-active")).Count()
+	require.NoError(t, cerr)
+	require.EqualValues(t, 0, count, "系统身份删除 active 实例任务后应已删除")
+}
+
+// TestSecFix_SystemDeleteTerminalInstanceRejected 系统身份删除终态实例上的任务应被
+// WithInstanceTx 拒绝（ErrInstanceTerminal）——证明系统分支已不再绕过实例锁。
+func TestSecFix_SystemDeleteTerminalInstanceRejected(t *testing.T) {
+	q := candGroupDB(t)
+	ctx := context.Background()
+	now := time.Now()
+
+	require.NoError(t, q.WfInstance.Create(&model.WfInstance{
+		ID: "inst-sys-terminal", ProcessID: "p1", Name: "sys_del_term",
+		Status: string(enums.InstanceStatusCompleted), StartUserID: "starter",
+		TenantID: "t1", CreatedBy: "starter", CreatedAt: now, EndedAt: &now,
+	}))
+	require.NoError(t, q.WfTask.Create(&model.WfTask{
+		ID: "task-sys-terminal", ProcessInstanceID: secFixStrPtr("inst-sys-terminal"), TaskDefKey: "approve",
+		Name: "审批", TaskType: "user_task", Status: string(enums.TaskStatusActive),
+		Assignee: secFixStrPtr("userA"), TenantID: "t1", CreatedBy: "system", CreatedAt: now,
+	}))
+
+	taskSvc := &TaskServiceImpl{taskDAO: dao.NewTaskDAOWithQuery(q), workflowEngine: &testEngineDouble{}}
+	err := taskSvc.DeleteTask(ctx, SystemActor(), "task-sys-terminal", "cleanup")
+	require.Error(t, err, "系统身份删除终态实例任务必须被拒绝")
+	require.True(t, errors.Is(err, ErrInstanceTerminal), "期望 ErrInstanceTerminal，got %v", err)
+
+	count, cerr := q.WfTask.WithContext(ctx).Where(q.WfTask.ID.Eq("task-sys-terminal")).Count()
+	require.NoError(t, cerr)
+	require.EqualValues(t, 1, count, "终态实例任务应保留（未被绕过锁直删）")
+}


### PR DESCRIPTION
🤖 人工智能辅助贡献  
使用的工具：Deepseek Harness / deepseek v4 pro
参与程度：全部变更代码。所有代码均已人工审核并通过验证。

## 背景

DeleteTask 的系统身份分支用 `userID == "system"` 字符串比对，命中后直接
`taskDAO.Delete` 并 return，绕过了 `WithInstanceTx` 实例行锁。这正是该方法顶部
注释自己警告的并发风险：删除与同实例的并发 Complete 竞争时，一边把任务推进
历史表、另一边又从活动表删除，最终留下重复终止态记录或丢失审批历史。

## 改动

- 系统身份识别改用 `IsSystemActor(&actor)`（canonical helper），去掉字符串比对；
- 移除系统身份的早退直删分支，改为与普通删除共用同一条 `WithInstanceTx →
  deleteTaskInternal` 持锁路径，从而获得实例行锁，并受"缺失实例/终态实例"守卫约束；
- 系统身份仍只跳过用户级鉴权（tenant/assignee/initiator），不做多余放宽。

## 行为变化说明

- 内部调用方（候选写入失败回滚、会签主任务回滚等）均在实例 active 期间触发，
  且对删除失败本就是 best-effort（log/ignore），不受影响；
- 终态实例上的系统删除现在返回 `ErrInstanceTerminal`（此前会绕过锁直删）。

## 测试

新增 `service/task_service_crud_system_delete_test.go`：
- 系统删除 active 实例任务 → 成功；
- 系统删除终态实例任务 → `ErrInstanceTerminal`、任务保留。

## 验证

- `gofmt` / `go vet ./service/...` / `go build ./...` / `go test ./...`（含 e2e）全部通过。