### PR TITLE
fix(task): 鉴权 fail-closed 边界收紧，堵住空 assignee/空身份/解析失败放行

### DIFF
--- a/service/task_event_dispatch_test.go
+++ b/service/task_event_dispatch_test.go
@@ -236,10 +236,26 @@ func ensureEventTestSchema(t *testing.T, db *gorm.DB) {
 	db.Exec("DELETE FROM wf_process")
 }
 
+// seedProcessForEvents inserts a minimal resolvable "proc-test" process
+// definition. requireActionEnabled 的 strict 解析（fail-closed）需要找到流程定义
+// 与节点才能判定"未配置 actionPermissions → 放行"；否则判定为解析失败 → 拒绝 transfer/withdraw。
+// 这里塞一个含 userTask1 节点的扁平 RuleChain DSL。
+func seedProcessForEvents(t *testing.T, engine WorkflowEngine) {
+	t.Helper()
+	def := `{"ruleChain":{"id":"proc-test","name":"test"},"metadata":{"firstNodeIndex":0,"nodes":[{"id":"userTask1","name":"approve","type":"userTask"}],"connections":[]}}`
+	if err := engine.GetDB().Exec(
+		`INSERT OR IGNORE INTO wf_process (id, tenant_id, name, version, definition_json) VALUES (?, ?, ?, ?, ?)`,
+		"proc-test", "tenant-test", "test-proc", 1, def,
+	).Error; err != nil {
+		t.Fatalf("seed process: %v", err)
+	}
+}
+
 // seedInstance inserts a minimal Active process instance row using the
 // engine's gorm.DB so TaskService/RuntimeService operations can find it.
 func seedInstance(t *testing.T, engine WorkflowEngine, instanceID, startUser string) {
 	t.Helper()
+	seedProcessForEvents(t, engine)
 	inst := &model.WfInstance{
 		ID:          instanceID,
 		ProcessID:   "proc-test",

--- a/service/task_service_action_permissions.go
+++ b/service/task_service_action_permissions.go
@@ -65,6 +65,65 @@ func resolveNodeActionPermissions(ctx context.Context, engine WorkflowEngine, in
 	return v
 }
 
+// resolveNodeActionPermissionsStrict 与上方的 lenient 版同源，但解析失败返回 error
+// 而非空 map。仅供 requireActionEnabled 做 fail-closed 校验：解析不出来说明无法判断
+// 设计器是否显式禁用了某动作，此时拒绝执行，避免解析失败绕过设计器的显式 disable。
+//
+// 返回值语义：
+//   - (nil, nil)：节点解析成功但未配置 actionPermissions 键 → 无显式禁用，放行；
+//   - (map, nil)：解析出 actionPermissions；
+//   - (nil, err)：实例/定义不存在、服务未注入、规则链解析失败、配置类型错误等。
+func resolveNodeActionPermissionsStrict(ctx context.Context, engine WorkflowEngine, instanceID, taskDefKey string) (map[string]interface{}, error) {
+	if instanceID == "" || taskDefKey == "" || engine == nil {
+		return nil, fmt.Errorf("resolve action permissions: invalid instance/defKey/engine")
+	}
+	runtimeService := engine.GetRuntimeService()
+	if runtimeService == nil {
+		return nil, fmt.Errorf("resolve action permissions: runtime service not injected")
+	}
+	instance, err := runtimeService.GetProcessInstance(ctx, ActorFromCtx(ctx), instanceID)
+	if err != nil {
+		return nil, fmt.Errorf("resolve action permissions: get instance: %w", err)
+	}
+	if instance == nil {
+		return nil, fmt.Errorf("resolve action permissions: instance not found")
+	}
+	if instance.ProcessID == "" {
+		return nil, fmt.Errorf("resolve action permissions: instance has no process")
+	}
+	processService := engine.GetProcessService()
+	if processService == nil {
+		return nil, fmt.Errorf("resolve action permissions: process service not injected")
+	}
+	procDef, err := processService.Get(ctx, instance.ProcessID)
+	if err != nil {
+		return nil, fmt.Errorf("resolve action permissions: get process: %w", err)
+	}
+	if procDef == nil {
+		return nil, fmt.Errorf("resolve action permissions: process not found")
+	}
+	rc, err := procDef.ToRuleChain()
+	if err != nil {
+		return nil, fmt.Errorf("resolve action permissions: parse rule chain: %w", err)
+	}
+	if rc == nil {
+		return nil, fmt.Errorf("resolve action permissions: rule chain is nil")
+	}
+	node, ok := rc.GetNode(taskDefKey)
+	if !ok {
+		return nil, fmt.Errorf("resolve action permissions: node %s not found", taskDefKey)
+	}
+	ap, ok := node.GetAdditionalInfo("actionPermissions")
+	if !ok {
+		return nil, nil
+	}
+	v, ok := ap.(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("resolve action permissions: actionPermissions has wrong type")
+	}
+	return v, nil
+}
+
 // resolveNodeFormPermissions 返回某节点 additionalInfo.formPermissions（字段级权限 r/w/h）。
 // 必须传入事务 scope：本函数在 WithInstanceTx 回调内调用，若走全局连接，
 // SQLite 等单写锁数据库会与外层事务互等形成死锁。
@@ -100,12 +159,16 @@ func resolveNodeFormPermissions(ctx context.Context, scope *InstanceScope, insta
 }
 
 // requireActionEnabled 校验流程设计器是否在 actionPermissions 中显式禁用了某动作。
-// 仅当"明确解析到 actionPermissions 且动作 key 显式 false"才拒绝；其余一律放行。
+// 解析失败时 fail-closed（拒绝该动作）——原实现解析失败返回空 map 降级放行，会让
+// 设计器显式 disable 在定义损坏/服务不可用等场景被绕过。
 func (s *TaskServiceImpl) requireActionEnabled(ctx context.Context, task *model.WfTask, actionKey string) error {
 	if task == nil || task.ProcessInstanceID == nil || *task.ProcessInstanceID == "" {
 		return nil
 	}
-	ap := resolveNodeActionPermissions(ctx, s.workflowEngine, *task.ProcessInstanceID, task.TaskDefKey)
+	ap, err := resolveNodeActionPermissionsStrict(ctx, s.workflowEngine, *task.ProcessInstanceID, task.TaskDefKey)
+	if err != nil {
+		return fmt.Errorf("cannot resolve action permissions for action %q: %w", actionKey, ErrPermissionDenied)
+	}
 	if designerDisabled(ap, actionKey) {
 		return fmt.Errorf("action %q disabled by designer on node %s: %w",
 			actionKey, task.TaskDefKey, ErrPermissionDenied)
@@ -169,7 +232,7 @@ func (s *TaskServiceImpl) requireReturnTarget(ctx context.Context, scope *Instan
 	instanceID := *task.ProcessInstanceID
 
 	// 1. 操作人须为当前任务受理人或候选人
-	if !s.isReturnOperator(ctx, task, userID) {
+	if !s.isReturnOperator(ctx, scope, task, userID) {
 		return fmt.Errorf("return by non-assignee/non-candidate %s: %w", userID, ErrPermissionDenied)
 	}
 
@@ -191,7 +254,9 @@ func (s *TaskServiceImpl) requireReturnTarget(ctx context.Context, scope *Instan
 }
 
 // isReturnOperator 判断 userID 是否为当前任务的受理人或候选人。
-func (s *TaskServiceImpl) isReturnOperator(ctx context.Context, task *model.WfTask, userID string) bool {
+// 候选池经 scope（tx-bound）读取——requireReturnTarget 在 WithInstanceTx 回调内执行，
+// 若走默认 DAO（s.taskAssigneeDAO）会 tx 逃逸，SQLite 等单写锁数据库与外层事务互等死锁。
+func (s *TaskServiceImpl) isReturnOperator(ctx context.Context, scope *InstanceScope, task *model.WfTask, userID string) bool {
 	if userID == "" {
 		return false
 	}
@@ -201,15 +266,31 @@ func (s *TaskServiceImpl) isReturnOperator(ctx context.Context, task *model.WfTa
 	if task.ProcessInstanceID == nil {
 		return false
 	}
-	candidates, err := s.GetTaskCandidates(ctx, *task.ProcessInstanceID, task.TaskDefKey)
-	if err != nil {
-		logrus.WithError(err).WithField("taskDefKey", task.TaskDefKey).
-			Warn("failed to query task candidates for return operator check; treating as non-candidate")
+	return s.isUserCandidateInScope(ctx, scope, task, userID)
+}
+
+// isUserCandidateInScope 在事务内展开候选池判断 userID 是否为候选人。
+// role/department 经 identity 展开；identity 缺失或展开失败按非候选处理（fail-closed，
+// 返回 false → 拒绝 return）。
+func (s *TaskServiceImpl) isUserCandidateInScope(ctx context.Context, scope *InstanceScope, task *model.WfTask, userID string) bool {
+	if scope == nil || task == nil || task.ProcessInstanceID == nil {
 		return false
 	}
-	for _, c := range candidates {
-		if c.EntityID == userID {
-			return true
+	rows, err := scope.TaskAssignees().GetByInstanceAndDefKey(ctx, task.TenantID, *task.ProcessInstanceID, task.TaskDefKey)
+	if err != nil {
+		logrus.WithError(err).WithField("taskDefKey", task.TaskDefKey).
+			Warn("failed to query task candidates in tx for return operator check; treating as non-candidate")
+		return false
+	}
+	identity := s.workflowEngine.GetIdentityService()
+	for _, c := range rows {
+		if c == nil {
+			continue
+		}
+		for _, m := range expandCandidateMembers(ctx, identity, task.TenantID, c.EntityType, c.EntityID) {
+			if m == userID {
+				return true
+			}
 		}
 	}
 	return false

--- a/service/task_service_assignment.go
+++ b/service/task_service_assignment.go
@@ -196,10 +196,15 @@ func (s *TaskServiceImpl) delegateInternal(ctx context.Context, scope *InstanceS
 	}
 
 	u := GetUserFromCtx(ctx)
-	if u == nil {
+	if u == nil || u.UserID == "" {
 		return ErrAuthenticationRequired
 	}
-	if task.Assignee != nil && *task.Assignee != "" && *task.Assignee != u.UserID {
+	// fail-closed：仅当前 assignee 可委派。未分配（pending）任务无从委派——此前
+	// assignee 为空时跳过校验，任意同租户用户可把未分配任务委派给他人。
+	if task.Assignee == nil || *task.Assignee == "" {
+		return fmt.Errorf("task is not assigned, cannot delegate: %w", ErrPermissionDenied)
+	}
+	if *task.Assignee != u.UserID {
 		return fmt.Errorf("task assigned to %s, current user %s: %w", *task.Assignee, u.UserID, ErrPermissionDenied)
 	}
 	// 禁止委派给自己:self-delegate 会让 Owner==Assignee==DelegateFrom,approve 时
@@ -424,8 +429,9 @@ func (s *TaskServiceImpl) transferInternal(ctx context.Context, scope *InstanceS
 	if u := GetUserFromCtx(ctx); u != nil && task.TenantID != u.TenantID {
 		return fmt.Errorf("%w: task", ErrNotFound)
 	}
-	// 操作人以显式参数 fromUserID 为准：只有任务当前 assignee 能转办
-	if task.Assignee != nil && *task.Assignee != fromUserID {
+	// 操作人以显式参数 fromUserID 为准：只有任务当前 assignee 能转办；
+	// 未分配任务（assignee 为空/nil）无从转办，fail-closed 拒绝（此前空 assignee 跳过校验）。
+	if task.Assignee == nil || *task.Assignee != fromUserID {
 		return fmt.Errorf("only assigned user can transfer task: %w", ErrPermissionDenied)
 	}
 

--- a/service/task_service_authz_fail_closed_test.go
+++ b/service/task_service_authz_fail_closed_test.go
@@ -1,0 +1,112 @@
+package service
+
+// Tests for PR3: authz fail-closed boundary tightening.
+//
+// 覆盖四种边界放行漏洞的修复：
+//  1. Delegate/Transfer 对空 assignee 任务 fail-open（未分配任务被任意用户委派/转办）
+//  2. AddSign/ReduceSign 对空 UserID 操作者放行
+//  3. requireActionEnabled 解析失败降级放行（设计器显式 disable 可被绕过）
+//  4. （锁内复校见 addSignInternal/reduceSignInternal/deleteTaskInternal 实现）
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/rulego/gflow-engine/dao"
+	"github.com/rulego/gflow-engine/model"
+	"github.com/rulego/gflow-engine/types/enums"
+)
+
+// newFailClosedSvc 构造绑定 secFixDB（wf_task 表）的 TaskServiceImpl。
+func newFailClosedSvc(t *testing.T) *TaskServiceImpl {
+	t.Helper()
+	q := secFixDB(t)
+	return &TaskServiceImpl{
+		taskDAO:        dao.NewTaskDAOWithQuery(q),
+		hiTaskDAO:      dao.NewHiTaskDAOWithQuery(q),
+		workflowEngine: &testEngineDouble{},
+	}
+}
+
+// seedFailClosedTask 写入一条 active 任务。assignee=="" 表示未分配（nil），
+// instanceID=="" 表示 orphan/draft（无实例）。
+func seedFailClosedTask(t *testing.T, svc *TaskServiceImpl, id, tenant, assignee, instanceID string) {
+	t.Helper()
+	task := &model.WfTask{
+		ID:         id,
+		TaskDefKey: "approve",
+		Name:       "审批",
+		TaskType:   "user_task",
+		Status:     string(enums.TaskStatusActive),
+		TenantID:   tenant,
+		CreatedBy:  "system",
+		CreatedAt:  time.Now(),
+	}
+	if assignee != "" {
+		task.Assignee = secFixStrPtr(assignee)
+	}
+	if instanceID != "" {
+		task.ProcessInstanceID = secFixStrPtr(instanceID)
+	}
+	require.NoError(t, svc.taskDAO.Create(context.Background(), task))
+}
+
+// TestFailClosed_DelegateUnassignedTaskRejected 验证：未分配（assignee=nil）任务
+// 不能被任意用户委派（此前空 assignee 跳过校验，fail-open）。
+func TestFailClosed_DelegateUnassignedTaskRejected(t *testing.T) {
+	svc := newFailClosedSvc(t)
+	seedFailClosedTask(t, svc, "task-del-unassigned", "t1", "", "")
+
+	err := svc.Delegate(context.Background(), Actor{UserID: "userA", UserName: "A", TenantID: "t1"}, "task-del-unassigned", "userB", "帮我办")
+	require.Error(t, err, "未分配任务不应允许委派")
+	require.True(t, errors.Is(err, ErrPermissionDenied), "期望 ErrPermissionDenied，got %v", err)
+}
+
+// TestFailClosed_TransferUnassignedTaskRejected 验证：未分配（assignee=nil）任务
+// 不能被任意用户转办（此前空 assignee 跳过校验，fail-open）。
+func TestFailClosed_TransferUnassignedTaskRejected(t *testing.T) {
+	svc := newFailClosedSvc(t)
+	seedFailClosedTask(t, svc, "task-tr-unassigned", "t1", "", "")
+
+	err := svc.Transfer(context.Background(), Actor{UserID: "userA", UserName: "A", TenantID: "t1"}, "task-tr-unassigned", "userC", "转给你")
+	require.Error(t, err, "未分配任务不应允许转办")
+	require.True(t, errors.Is(err, ErrPermissionDenied), "期望 ErrPermissionDenied，got %v", err)
+}
+
+// TestFailClosed_AddSignEmptyOperatorRejected 验证：空 UserID 的操作者无法加签
+// （此前空串 assignee 可与空串 operator 匹配，退化放行）。
+func TestFailClosed_AddSignEmptyOperatorRejected(t *testing.T) {
+	svc := newFailClosedSvc(t)
+	seedFailClosedTask(t, svc, "task-sign", "t1", "userA", "")
+
+	err := svc.AddSign(context.Background(), Actor{UserID: "", UserName: "", TenantID: "t1"}, "task-sign", []string{"userB"}, "加签")
+	require.Error(t, err, "空操作者身份不应允许加签")
+	require.True(t, errors.Is(err, ErrPermissionDenied), "期望 ErrPermissionDenied，got %v", err)
+}
+
+// TestFailClosed_ReduceSignEmptyOperatorRejected 验证：空 UserID 的操作者无法减签。
+func TestFailClosed_ReduceSignEmptyOperatorRejected(t *testing.T) {
+	svc := newFailClosedSvc(t)
+	seedFailClosedTask(t, svc, "task-rsign", "t1", "userA", "")
+
+	err := svc.ReduceSign(context.Background(), Actor{UserID: "", UserName: "", TenantID: "t1"}, "task-rsign", []string{"userB"}, "减签")
+	require.Error(t, err, "空操作者身份不应允许减签")
+	require.True(t, errors.Is(err, ErrPermissionDenied), "期望 ErrPermissionDenied，got %v", err)
+}
+
+// TestFailClosed_ActionPermissionsResolutionFailureRejected 验证：任务关联了实例但
+// 设计器配置无法解析（这里 workflowEngine 未注入运行时服务）时，requireActionEnabled
+// 必须 fail-closed 拒绝，而非降级放行（此前解析失败返回空 map → 放行，可绕过设计器显式 disable）。
+func TestFailClosed_ActionPermissionsResolutionFailureRejected(t *testing.T) {
+	svc := newFailClosedSvc(t)
+	seedFailClosedTask(t, svc, "task-ap", "t1", "userA", "inst-x")
+
+	// userA 是合法 assignee（满足 assignee 校验），但 actionPermissions 解析失败 → 拒绝
+	err := svc.Transfer(context.Background(), Actor{UserID: "userA", UserName: "A", TenantID: "t1"}, "task-ap", "userC", "转办")
+	require.Error(t, err, "设计器配置解析失败时动作应被拒绝（fail-closed）")
+	require.True(t, errors.Is(err, ErrPermissionDenied), "期望 ErrPermissionDenied，got %v", err)
+}

--- a/service/task_service_crud.go
+++ b/service/task_service_crud.go
@@ -170,11 +170,46 @@ func (s *TaskServiceImpl) DeleteTask(ctx context.Context, actor Actor, taskID, r
 	})
 }
 
+// recheckDeleteTaskAuthz 锁内复校验纯字段鉴权（租户 + assignee）。
+// initiator 校验（未分配任务的发起人）不在此复跑——instance.StartUserID 不可变，锁外已校验过；
+// 这里只防"廉价读后任务被并发改派（assignee 变化）"的 TOCTOU 窗口。
+func recheckDeleteTaskAuthz(ctx context.Context, task *model.WfTask) error {
+	u := GetUserFromCtx(ctx)
+	if u == nil || u.UserID == "" {
+		return ErrAuthenticationRequired
+	}
+	// 系统身份（引擎内部级联清理）跳过用户级校验：系统租户为空，无法与任务租户比照。
+	// 与 DeleteTask 顶部"系统身份免用户级校验"口径一致，也便于后续系统删除路径复用本方法。
+	if IsSystemActor(u) {
+		return nil
+	}
+	if task.TenantID != u.TenantID {
+		return fmt.Errorf("%w: task", ErrNotFound)
+	}
+	if task.Assignee != nil && *task.Assignee != "" && *task.Assignee != u.UserID {
+		return fmt.Errorf("task assigned to %s, operator %s: %w", *task.Assignee, u.UserID, ErrPermissionDenied)
+	}
+	return nil
+}
+
 // deleteTaskInternal 在已持有实例行锁的事务内执行 DeleteTask 实际逻辑。
-// 幂等：任务在持锁期间可能已被并发分支删除，再次 Delete 不应失败。
 // reason 当前未持久化（保留参数以匹配 public 签名），未来可写入审计日志。
 func (s *TaskServiceImpl) deleteTaskInternal(ctx context.Context, scope *InstanceScope, taskID string) error {
 	taskDAO := scope.Tasks()
+
+	// 锁内复校：廉价读发生在加锁之前，任务可能在锁外校验后被并发改派。
+	// 按持锁后的最新快照复跑纯字段鉴权，收窄 TOCTOU 窗口。
+	task, err := taskDAO.Get(ctx, taskID)
+	if err != nil {
+		return fmt.Errorf("failed to get task: %w", err)
+	}
+	if task == nil {
+		return fmt.Errorf("%w: task", ErrNotFound)
+	}
+	if err := recheckDeleteTaskAuthz(ctx, task); err != nil {
+		return err
+	}
+
 	if err := taskDAO.Delete(ctx, taskID); err != nil {
 		return fmt.Errorf("failed to delete task: %w", err)
 	}

--- a/service/task_service_sign.go
+++ b/service/task_service_sign.go
@@ -11,18 +11,26 @@ import (
 
 	"github.com/sirupsen/logrus"
 
+	"github.com/rulego/gflow-engine/dao"
 	"github.com/rulego/gflow-engine/model"
 	"github.com/rulego/gflow-engine/types/dto"
 	"github.com/rulego/gflow-engine/types/enums"
 )
 
-// authorizeSignOperator 校验加签/减签操作者身份。
+// authorizeSignOperator 校验加签/减签操作者身份（用默认 DAO，供锁外廉价校验）。
 // 普通任务：须为 task.Assignee；countersign 父任务（无直接 assignee，审批人在子任务上）：
 // 须为该父任务任一子任务的 assignee。防越权加签/减签他人任务。
 // 注意：不做超管 bypass——加签/减签是任务参与人动作，即便是超管也须是该节点参与人。
 func (s *TaskServiceImpl) authorizeSignOperator(ctx context.Context, task *model.WfTask) error {
+	return s.authorizeSignOperatorWithDAO(ctx, s.taskDAO, task)
+}
+
+// authorizeSignOperatorWithDAO 用指定 TaskDAO 校验操作者身份。
+// 传 s.taskDAO 用于锁外廉价校验；传 scope.Tasks() 在实例锁内按最新快照复跑（收窄
+// TOCTOU 窗口：任务可能在锁外校验后被并发改派）。
+func (s *TaskServiceImpl) authorizeSignOperatorWithDAO(ctx context.Context, taskDAO *dao.TaskDAO, task *model.WfTask) error {
 	u := GetUserFromCtx(ctx)
-	if u == nil {
+	if u == nil || u.UserID == "" {
 		return fmt.Errorf("authentication required: %w", ErrPermissionDenied)
 	}
 	if task.TenantID != u.TenantID {
@@ -33,8 +41,8 @@ func (s *TaskServiceImpl) authorizeSignOperator(ctx context.Context, task *model
 		return nil
 	}
 	// countersign 父任务：操作者是任一子任务 assignee 即放行
-	if task.ID != "" {
-		if subTasks, err := s.taskDAO.GetByParentID(ctx, task.ID); err == nil {
+	if taskDAO != nil && task.ID != "" {
+		if subTasks, err := taskDAO.GetByParentID(ctx, task.ID); err == nil {
 			for _, st := range subTasks {
 				if st.Assignee != nil && *st.Assignee == u.UserID {
 					return nil
@@ -92,6 +100,11 @@ func (s *TaskServiceImpl) addSignInternal(ctx context.Context, scope *InstanceSc
 	}
 	if task == nil {
 		return fmt.Errorf("%w: task", ErrNotFound)
+	}
+
+	// 锁内复校：任务可能在锁外廉价校验后被并发改派，按最新快照复跑操作者鉴权。
+	if err := s.authorizeSignOperatorWithDAO(ctx, taskDAO, task); err != nil {
+		return err
 	}
 
 	now := time.Now()
@@ -214,6 +227,11 @@ func (s *TaskServiceImpl) reduceSignInternal(ctx context.Context, scope *Instanc
 	}
 	if task == nil {
 		return fmt.Errorf("%w: task", ErrNotFound)
+	}
+
+	// 锁内复校：任务可能在锁外廉价校验后被并发改派，按最新快照复跑操作者鉴权。
+	if err := s.authorizeSignOperatorWithDAO(ctx, taskDAO, task); err != nil {
+		return err
 	}
 
 	for _, userID := range userIDs {


### PR DESCRIPTION
🤖 人工智能辅助贡献  
使用的工具：Deepseek Harness / deepseek v4 pro
参与程度：全部变更代码。所有代码均已人工审核并通过验证。

## 背景

边界场景被静默放行：
- Delegate/Transfer 对空 assignee（未分配）任务跳过 assignee 校验，任意同租户用户可委派/转办；
- AddSign/ReduceSign 空串 UserID 可与空串 assignee 匹配放行；
- requireActionEnabled 解析失败时返回空 map 降级放行，设计器显式 disable 可被绕过；
- 锁内 isReturnOperator 走默认 DAO 造成 tx 逃逸（SQLite 单写锁自死锁）；
- DeleteTask/AddSign/ReduceSign 锁外廉价鉴权与锁内 mutation 之间存在 TOCTOU 窗口。

## 改动

- Delegate/Transfer：未分配任务（assignee 为空/nil）拒绝，仅当前 assignee 可操作；
- authorizeSignOperator：拒绝空 UserID 操作者；
- requireActionEnabled：新增 resolveNodeActionPermissionsStrict，解析失败 fail-closed 拒绝；
  UI 装配路径仍用原 lenient 版（只影响按钮显隐，不影响安全校验）；
- AddSign/ReduceSign/DeleteTask：锁内 scope.Tasks() 重读并复跑纯字段鉴权（系统身份跳过用户级校验）；
- isReturnOperator 改走 scope.TaskAssignees()（tx-bound），消除锁内 tx 逃逸。

## 行为变化说明

- 任务关联实例但设计器配置不可解析（定义缺失/服务未注入/规则链损坏）时，
  transfer/delegate/withdraw/addSign/reduceSign 将被拒绝（fail-closed），
  这是有意的可用性/安全取舍。

## 测试

新增 task_service_authz_fail_closed_test.go（5 例）；事件派发测试补 proc-test
流程定义以适配 strict 解析。

## 验证

gofmt / go vet ./... / go build ./... / go test ./...（含 e2e）全部通过。