### PR TITLE
fix(service): 补齐变更类接口的属主/管理员鉴权（横向越权）

### DIFF
--- a/components/node_topology.go
+++ b/components/node_topology.go
@@ -67,9 +67,11 @@ func terminateInstance(rs service.RuntimeService, nodeID string, ctx types.RuleC
 		ctx.TellFailure(msg, fmt.Errorf("reject: runtime service unavailable"))
 		return
 	}
-	termCtx := service.WithEventSource(ctx.GetContext(), service.EventSourceReject)
+	termCtx := service.WithInternalCallingMode(service.WithEventSource(ctx.GetContext(), service.EventSourceReject))
 	// 显式 actor：驳回级联终止归属实际驳回人（ctx 身份）；ctx 无身份时按系统动作处理，
-	// 并从链元数据补齐租户（TerminateProcessInstance 的租户校验依赖 TenantID）
+	// 并从链元数据补齐租户（TerminateProcessInstance 的租户校验依赖 TenantID）；
+	// WithInternalCallingMode 标记为引擎内部级联，跳过实例属主校验（驳回人是对该实例
+	// 有审批权的参与人而非发起人，终止是回路语义驱动的副作用，不是越权终止他人实例）。
 	actor := service.ActorFromCtx(termCtx)
 	if actor.TenantID == "" {
 		actor.TenantID = metaValue(msg, constants.KeyTenantID)

--- a/service/delay_rescue_test.go
+++ b/service/delay_rescue_test.go
@@ -150,7 +150,7 @@ func TestRescueExpiredDelayTask_Validation(t *testing.T) {
 	rs := newDelayRescueRS(q)
 	now := time.Now()
 	ctx := context.Background()
-	sysActor := Actor{UserID: "sys", TenantID: "t1"}
+	sysActor := Actor{UserID: "sys", TenantID: "t1", SuperAdmin: true}
 
 	// 实例供任务关联
 	require.NoError(t, dao.NewInstanceDAOWithQuery(q).Create(ctx, &model.WfInstance{
@@ -218,7 +218,7 @@ func TestRescueExpiredDelayTask_GateBusy(t *testing.T) {
 	rs.workflowEngine = &gateTestEngine{l: shared}
 	now := time.Now()
 	ctx := context.Background()
-	sysActor := Actor{UserID: "sys", TenantID: "t1"}
+	sysActor := Actor{UserID: "sys", TenantID: "t1", SuperAdmin: true}
 
 	require.NoError(t, dao.NewInstanceDAOWithQuery(q).Create(ctx, &model.WfInstance{
 		ID: "inst-busy", ProcessID: "proc-d", Name: "d", Status: string(enums.InstanceStatusActive),
@@ -243,7 +243,7 @@ func TestReDriveProcessInstance_GateBusy(t *testing.T) {
 	rs.workflowEngine = &gateTestEngine{l: shared}
 	now := time.Now()
 	ctx := context.Background()
-	sysActor := Actor{UserID: "sys", TenantID: "t1"}
+	sysActor := Actor{UserID: "sys", TenantID: "t1", SuperAdmin: true}
 
 	activity := "node_ai"
 	require.NoError(t, dao.NewInstanceDAOWithQuery(q).Create(ctx, &model.WfInstance{

--- a/service/operator_authz.go
+++ b/service/operator_authz.go
@@ -1,0 +1,51 @@
+package service
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/rulego/gflow-engine/model"
+)
+
+// requireInstanceOwnerAuthorized 校验流程实例级生命周期变更（终止/挂起/删除/激活/重启/
+// 强恢复/重驱动/救援）的属主/管理员权限。放行三类：实例发起人自己、管理员
+// （SuperAdmin）、系统身份；其余（含无操作人）一律拒绝（fail-closed）。
+//
+// 引擎内部级联（CallingModeInternal，如失败终止 handleProcessInstanceFailure、驳回
+// 级联终止 terminateInstance）携带的是"参与该实例的真实用户"而非发起人，属流程语义
+// 驱动的副作用，不套用属主规则——这些调用方已显式以 WithInternalCallingMode 标记 ctx，
+// 本方法对其跳过，与 ensureTenantAccess（租户仍照常校验）互不干扰。
+func requireInstanceOwnerAuthorized(ctx context.Context, instance *model.WfInstance) error {
+	if GetCallingMode(ctx) == CallingModeInternal {
+		return nil
+	}
+	u := GetUserFromCtx(ctx)
+	if u == nil || u.UserID == "" {
+		return fmt.Errorf("operator identity required: %w", ErrAuthenticationRequired)
+	}
+	if u.SuperAdmin || IsSystemActor(u) {
+		return nil
+	}
+	if instance.StartUserID != "" && instance.StartUserID == u.UserID {
+		return nil
+	}
+	return fmt.Errorf("only the process initiator (or admin) can perform this operation: %w", ErrPermissionDenied)
+}
+
+// requireTaskOperatorAuthorized 校验任务属性变更（优先级/截止时间等）的操作权限：
+// 任务归属人（assignee）、管理员或系统身份。无操作人、或任务未指派给当前操作人
+// 的任务一律拒绝（fail-closed）。带 assignee 的任务仅其本人（或管理员/系统）可改；
+// 未指派任务仅管理员/系统可改。
+func requireTaskOperatorAuthorized(ctx context.Context, task *model.WfTask) error {
+	u := GetUserFromCtx(ctx)
+	if u == nil || u.UserID == "" {
+		return fmt.Errorf("operator identity required: %w", ErrAuthenticationRequired)
+	}
+	if u.SuperAdmin || IsSystemActor(u) {
+		return nil
+	}
+	if task.Assignee != nil && *task.Assignee != "" && *task.Assignee == u.UserID {
+		return nil
+	}
+	return fmt.Errorf("task is not assigned to current user: %w", ErrPermissionDenied)
+}

--- a/service/operator_authz_test.go
+++ b/service/operator_authz_test.go
@@ -1,0 +1,103 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/rulego/gflow-engine/model"
+)
+
+// authzCtx 组装带操作人 + 调用模式的 ctx，供属主/归属校验单测使用。
+func authzCtx(actor *Actor, mode CallingMode) context.Context {
+	ctx := context.Background()
+	if mode != CallingModeUnknown {
+		ctx = SetCallingMode(ctx, mode)
+	}
+	if actor != nil {
+		ctx = SetUserToCtx(ctx, actor)
+	}
+	return ctx
+}
+
+func TestRequireInstanceOwnerAuthorized(t *testing.T) {
+	inst := &model.WfInstance{StartUserID: "owner", TenantID: "t1"}
+
+	cases := []struct {
+		name    string
+		actor   *Actor
+		mode    CallingMode
+		wantErr error
+	}{
+		{"owner allowed", &Actor{UserID: "owner", TenantID: "t1"}, CallingModeAPI, nil},
+		{"super admin allowed", &Actor{UserID: "admin", TenantID: "t1", SuperAdmin: true}, CallingModeAPI, nil},
+		{"system allowed", &Actor{UserID: "system"}, CallingModeAPI, nil},
+		{"non-owner same tenant denied", &Actor{UserID: "eve", TenantID: "t1"}, CallingModeAPI, ErrPermissionDenied},
+		{"nil actor denied", nil, CallingModeAPI, ErrAuthenticationRequired},
+		{"empty user denied", &Actor{UserID: "", TenantID: "t1"}, CallingModeAPI, ErrAuthenticationRequired},
+		{"internal cascade skips owner check", &Actor{UserID: "eve", TenantID: "t1"}, CallingModeInternal, nil},
+		{"unknown mode treated as external", &Actor{UserID: "eve", TenantID: "t1"}, CallingModeUnknown, ErrPermissionDenied},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := requireInstanceOwnerAuthorized(authzCtx(tc.actor, tc.mode), inst)
+			if tc.wantErr == nil {
+				require.NoError(t, err)
+			} else {
+				require.ErrorIs(t, err, tc.wantErr)
+			}
+		})
+	}
+
+	// 系统触发（StartUserID 为空）的实例：非管理员/非系统用户不得操作。
+	t.Run("empty starter non-admin denied", func(t *testing.T) {
+		err := requireInstanceOwnerAuthorized(
+			authzCtx(&Actor{UserID: "eve", TenantID: "t1"}, CallingModeAPI),
+			&model.WfInstance{StartUserID: "", TenantID: "t1"})
+		require.ErrorIs(t, err, ErrPermissionDenied)
+	})
+}
+
+func TestRequireTaskOperatorAuthorized(t *testing.T) {
+	assignee := "owner"
+	assigned := &model.WfTask{Assignee: &assignee, TenantID: "t1"}
+	unassigned := &model.WfTask{Assignee: nil, TenantID: "t1"}
+
+	cases := []struct {
+		name    string
+		task    *model.WfTask
+		actor   *Actor
+		wantErr error
+	}{
+		{"assignee allowed", assigned, &Actor{UserID: "owner", TenantID: "t1"}, nil},
+		{"super admin allowed", assigned, &Actor{UserID: "admin", TenantID: "t1", SuperAdmin: true}, nil},
+		{"system allowed", assigned, &Actor{UserID: "system"}, nil},
+		{"non-assignee denied", assigned, &Actor{UserID: "eve", TenantID: "t1"}, ErrPermissionDenied},
+		{"unassigned non-admin denied", unassigned, &Actor{UserID: "eve", TenantID: "t1"}, ErrPermissionDenied},
+		{"nil actor denied", assigned, nil, ErrAuthenticationRequired},
+		{"empty user denied", assigned, &Actor{UserID: "", TenantID: "t1"}, ErrAuthenticationRequired},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := requireTaskOperatorAuthorized(SetUserToCtx(context.Background(), tc.actor), tc.task)
+			if tc.wantErr == nil {
+				require.NoError(t, err)
+			} else {
+				require.ErrorIs(t, err, tc.wantErr)
+			}
+		})
+	}
+}
+
+// 额外的编译期/语义哨兵：确保 ErrPermissionDenied 与 ErrAuthenticationRequired
+// 都可被 errors.Is 捕获（防止 helper 用 fmt.Errorf 裸字符串拼接丢链）。
+func TestOperatorAuthzErrorsWrapSentinel(t *testing.T) {
+	require.True(t, errors.Is(
+		requireInstanceOwnerAuthorized(authzCtx(&Actor{UserID: "eve", TenantID: "t1"}, CallingModeAPI), &model.WfInstance{StartUserID: "owner", TenantID: "t1"}),
+		ErrPermissionDenied))
+	require.True(t, errors.Is(
+		requireInstanceOwnerAuthorized(authzCtx(nil, CallingModeAPI), &model.WfInstance{StartUserID: "owner", TenantID: "t1"}),
+		ErrAuthenticationRequired))
+}

--- a/service/runtime_lifecycle_guard_test.go
+++ b/service/runtime_lifecycle_guard_test.go
@@ -61,7 +61,9 @@ func TestSuspendProcessInstance_DraftRejected(t *testing.T) {
 func TestTerminateInTx_NotifiesOnlyLiveAssignees(t *testing.T) {
 	rs, _ := lifecycleDB(t)
 	q := secFixDB(t)
-	ctx := context.Background()
+	// TerminateInTx 是内部 API（生产路径由 TerminateProcessInstance/Withdraw 在已通过属主/
+	// 租户校验后调用）；本测试直接驱动收尾逻辑，故标记为引擎内部模式，跳过属主重校验。
+	ctx := WithInternalCallingMode(context.Background())
 	now := time.Now()
 
 	require.NoError(t, rs.instanceDAO.Create(ctx, &model.WfInstance{

--- a/service/runtime_service_impl.go
+++ b/service/runtime_service_impl.go
@@ -326,6 +326,9 @@ func (s *RuntimeServiceImpl) DeleteProcessInstance(ctx context.Context, actor Ac
 		if err := ensureTenantAccess(ctx, "process instance", instance.TenantID); err != nil {
 			return err
 		}
+		if err := requireInstanceOwnerAuthorized(ctx, instance); err != nil {
+			return err
+		}
 
 		// 2. 草稿未进入流转，无历史可归档，直接物理删除
 		if instance.Status == string(enums.InstanceStatusDraft) {
@@ -495,6 +498,9 @@ func (s *RuntimeServiceImpl) suspendProcessInstanceInternal(ctx context.Context,
 
 	if currentUser := GetUserFromCtx(ctx); currentUser != nil {
 		if err := ensureTenantAccess(ctx, "process instance", instance.TenantID); err != nil {
+			return err
+		}
+		if err := requireInstanceOwnerAuthorized(ctx, instance); err != nil {
 			return err
 		}
 		instance.UpdatedBy = &currentUser.UserName
@@ -669,6 +675,14 @@ func (s *RuntimeServiceImpl) activateProcessInstanceInternal(ctx context.Context
 		}
 		initiator := Actor{UserID: instance.StartUserID, TenantID: instance.TenantID}
 		if err := s.checkStarterScope(ctx, processDef, initiator); err != nil {
+			return nil, false, err
+		}
+	}
+
+	// 挂起恢复（非草稿路径）也要求实例属主/管理员身份，与终止/删除/重启/强恢复等
+	// 实例级变更口径一致（fail-closed）。草稿激活已在上面按创建者校验。
+	if instance.Status != string(enums.InstanceStatusDraft) {
+		if err := requireInstanceOwnerAuthorized(ctx, instance); err != nil {
 			return nil, false, err
 		}
 	}
@@ -927,6 +941,9 @@ func (s *RuntimeServiceImpl) RestartProcessInstance(ctx context.Context, actor A
 	}
 
 	if err := ensureTenantAccess(ctx, "process instance", original.TenantID); err != nil {
+		return "", err
+	}
+	if err := requireInstanceOwnerAuthorized(ctx, original); err != nil {
 		return "", err
 	}
 
@@ -1307,6 +1324,9 @@ func (s *RuntimeServiceImpl) ForceResumeInstance(ctx context.Context, actor Acto
 	if err := ensureTenantAccess(ctx, "process instance", inst.TenantID); err != nil {
 		return err
 	}
+	if err := requireInstanceOwnerAuthorized(ctx, inst); err != nil {
+		return err
+	}
 	if enums.IsTerminalInstanceStatus(enums.InstanceStatus(inst.Status)) {
 		return fmt.Errorf("process instance is in terminal status: %s", inst.Status)
 	}
@@ -1672,6 +1692,9 @@ func (s *RuntimeServiceImpl) RescueExpiredDelayTask(ctx context.Context, actor A
 	if instance.Status != string(enums.InstanceStatusActive) {
 		return fmt.Errorf("process instance %s is %s, only active instances can be rescued", instanceID, instance.Status)
 	}
+	if err := requireInstanceOwnerAuthorized(ctx, instance); err != nil {
+		return err
+	}
 
 	// 判定与重驱须与对端副本的驱动互斥（同 RestoreProcessInstance），救援路径
 	// 走严格模式：拿不到门闩说明计时器所属副本可能仍在驱动，让位等下一拍
@@ -1767,6 +1790,9 @@ func (s *RuntimeServiceImpl) ReDriveProcessInstance(ctx context.Context, actor A
 	}
 	if instance.Status != string(enums.InstanceStatusActive) {
 		return fmt.Errorf("instance %s is %s, only active instances can be re-driven", processInstanceID, instance.Status)
+	}
+	if err := requireInstanceOwnerAuthorized(ctx, instance); err != nil {
+		return err
 	}
 	node := ""
 	if instance.CurrentActivity != nil {
@@ -2127,6 +2153,9 @@ func (s *RuntimeServiceImpl) TerminateInTx(ctx context.Context, tx *query.Query,
 	}
 
 	if err := ensureTenantAccess(ctx, "process instance", instance.TenantID); err != nil {
+		return nil, err
+	}
+	if err := requireInstanceOwnerAuthorized(ctx, instance); err != nil {
 		return nil, err
 	}
 

--- a/service/task_event_dispatch_test.go
+++ b/service/task_event_dispatch_test.go
@@ -417,7 +417,7 @@ func TestEngine_FiresTerminatedEventOnTerminate(t *testing.T) {
 	seedInstance(t, engine, instanceID, "starter-7")
 	seedActiveTask(t, engine, instanceID, "userTask1", "assignee-7")
 
-	if err := engine.GetRuntimeService().TerminateProcessInstance(context.Background(), Actor{UserID: "admin-s", TenantID: "tenant-test"}, instanceID, "测试终止"); err != nil {
+	if err := engine.GetRuntimeService().TerminateProcessInstance(context.Background(), Actor{UserID: "admin-s", TenantID: "tenant-test", SuperAdmin: true}, instanceID, "测试终止"); err != nil {
 		t.Fatalf("TerminateProcessInstance failed: %v", err)
 	}
 
@@ -757,8 +757,9 @@ func TestEngine_FiresSuspendedAndActivatedEvents(t *testing.T) {
 	// current_activity 非空：激活后不走草稿启动分支
 	engine.GetDB().Exec("UPDATE wf_instance SET current_activity = 'node1' WHERE id = ?", instanceID)
 
-	ctx := SetUserToCtx(context.Background(), newUserIdentity("admin-s"))
-	if err := rt.SuspendProcessInstance(ctx, *newUserIdentity("admin-s"), instanceID); err != nil {
+	adminActor := Actor{UserID: "admin-s", UserName: "admin-s", TenantID: "tenant-test", SuperAdmin: true}
+	ctx := SetUserToCtx(context.Background(), &adminActor)
+	if err := rt.SuspendProcessInstance(ctx, adminActor, instanceID); err != nil {
 		t.Fatalf("SuspendProcessInstance failed: %v", err)
 	}
 	evs := rec.waitForEvents(t, 1, 2*time.Second)
@@ -782,7 +783,7 @@ func TestEngine_FiresSuspendedAndActivatedEvents(t *testing.T) {
 		t.Errorf("suspended ToUsers = %v, want [starter-s]", suspended.ToUsers)
 	}
 
-	if err := rt.ActivateProcessInstance(ctx, *newUserIdentity("admin-s"), instanceID); err != nil {
+	if err := rt.ActivateProcessInstance(ctx, adminActor, instanceID); err != nil {
 		t.Fatalf("ActivateProcessInstance failed: %v", err)
 	}
 	evs = rec.waitForEvents(t, 2, 2*time.Second)

--- a/service/task_service_candidates.go
+++ b/service/task_service_candidates.go
@@ -174,10 +174,26 @@ func (s *TaskServiceImpl) GetTaskCandidates(ctx context.Context, processInstance
 // AddCandidates 批量写入任务候选人（每条 entityID 一条 wf_task_assignee 记录）。
 func (s *TaskServiceImpl) AddCandidates(ctx context.Context, actor Actor, taskID, entityType string, entityIDs []string) error {
 	ctx = bindActor(ctx, actor)
-	tenantID := actor.TenantID
 	if taskID == "" || entityType == "" {
 		return fmt.Errorf("taskID and entityType cannot be empty")
 	}
+	// 候选人池变更属改派类管理操作：强制管理员/系统身份（与 Reassign/SetAssignee 一致），
+	// 否则任意同租户用户可自助 AddCandidates(自己)→Claim→审批劫持任务。
+	if err := requireAdminIdentity(&actor); err != nil {
+		return err
+	}
+	// 任务存在性 + 租户一致性：跨租户按 NotFound 处理，不泄露任务存在性。
+	task, err := s.taskDAO.Get(ctx, taskID)
+	if err != nil {
+		return fmt.Errorf("failed to get task: %w", err)
+	}
+	if task == nil {
+		return fmt.Errorf("%w: task", ErrNotFound)
+	}
+	if task.TenantID != actor.TenantID {
+		return fmt.Errorf("%w: task", ErrNotFound)
+	}
+	tenantID := actor.TenantID
 	if len(entityIDs) == 0 {
 		return nil
 	}
@@ -207,10 +223,24 @@ func (s *TaskServiceImpl) AddCandidates(ctx context.Context, actor Actor, taskID
 // RemoveCandidates 移除任务候选人（按 entityType + entityIDs 批量删除，单 SQL 原子）。
 func (s *TaskServiceImpl) RemoveCandidates(ctx context.Context, actor Actor, taskID, entityType string, entityIDs []string) error {
 	ctx = bindActor(ctx, actor)
-	tenantID := actor.TenantID
 	if taskID == "" || entityType == "" {
 		return fmt.Errorf("taskID and entityType cannot be empty")
 	}
+	// 同 AddCandidates：候选人池变更强制管理员/系统身份，并校验任务存在性与租户一致性。
+	if err := requireAdminIdentity(&actor); err != nil {
+		return err
+	}
+	task, err := s.taskDAO.Get(ctx, taskID)
+	if err != nil {
+		return fmt.Errorf("failed to get task: %w", err)
+	}
+	if task == nil {
+		return fmt.Errorf("%w: task", ErrNotFound)
+	}
+	if task.TenantID != actor.TenantID {
+		return fmt.Errorf("%w: task", ErrNotFound)
+	}
+	tenantID := actor.TenantID
 	filtered := make([]string, 0, len(entityIDs))
 	for _, eid := range entityIDs {
 		if eid != "" {

--- a/service/task_service_candidates_test.go
+++ b/service/task_service_candidates_test.go
@@ -162,6 +162,32 @@ func TestAddCandidates_WritesRoleRows(t *testing.T) {
 	}
 }
 
+// TestAddCandidates_Authz 验证候选人池变更的鉴权：非管理员/非系统被拒（防自助
+// 加候选→Claim→审批劫持）、跨租户按 NotFound 隐藏、管理员同租户放行。
+func TestAddCandidates_Authz(t *testing.T) {
+	q := candGroupDB(t)
+	ctx := context.Background()
+	seedRoleInstance(t, q, "task-authz", "inst-authz")
+	taskSvc := newCandSvc(q, newMockIdentity())
+
+	// 同租户普通用户（非 assignee 非候选人非管理员）自助加候选 → 拒绝
+	err := taskSvc.AddCandidates(ctx, Actor{UserID: "eve", TenantID: "t1"}, "task-authz", "person", []string{"eve"})
+	require.ErrorIs(t, err, ErrPermissionDenied)
+	err = taskSvc.RemoveCandidates(ctx, Actor{UserID: "eve", TenantID: "t1"}, "task-authz", "person", []string{"eve"})
+	require.ErrorIs(t, err, ErrPermissionDenied)
+
+	// 管理员但跨租户 → NotFound（隐藏任务存在性）
+	err = taskSvc.AddCandidates(ctx, Actor{UserID: "admin", TenantID: "other", SuperAdmin: true}, "task-authz", "person", []string{"eve"})
+	require.ErrorIs(t, err, ErrNotFound)
+
+	// 管理员 + 目标不存在 → NotFound
+	err = taskSvc.AddCandidates(ctx, Actor{UserID: "admin", TenantID: "t1", SuperAdmin: true}, "task-nope", "person", []string{"eve"})
+	require.ErrorIs(t, err, ErrNotFound)
+
+	// 管理员 + 同租户 → 成功
+	require.NoError(t, taskSvc.AddCandidates(ctx, Actor{UserID: "admin", TenantID: "t1", SuperAdmin: true}, "task-authz", "person", []string{"carol"}))
+}
+
 // TestClaim_RoleMember_Passes 验证 role 成员可认领（identity 展开 role→members 命中）。
 func TestClaim_RoleMember_Passes(t *testing.T) {
 	q := candGroupDB(t)

--- a/service/task_service_status.go
+++ b/service/task_service_status.go
@@ -52,6 +52,11 @@ func (s *TaskServiceImpl) setPriorityInternal(ctx context.Context, scope *Instan
 	if task == nil {
 		return fmt.Errorf("%w: task", ErrNotFound)
 	}
+	// 归属校验：仅任务归属人/管理员/系统可改优先级（fail-closed），
+	// 对齐 Suspend/Activate 的 assignee 校验，防止同租户横向越权改写他人任务。
+	if err := requireTaskOperatorAuthorized(ctx, task); err != nil {
+		return err
+	}
 	if task.Priority == int32(priority) {
 		return nil
 	}
@@ -108,6 +113,10 @@ func (s *TaskServiceImpl) setDueDateInternal(ctx context.Context, scope *Instanc
 	}
 	if task == nil {
 		return fmt.Errorf("%w: task", ErrNotFound)
+	}
+	// 归属校验：仅任务归属人/管理员/系统可改到期时间（fail-closed），同 setPriorityInternal。
+	if err := requireTaskOperatorAuthorized(ctx, task); err != nil {
+		return err
 	}
 	task.DueDate = &dueDate
 	username := ""

--- a/test/e2e/candidate_claim_test.go
+++ b/test/e2e/candidate_claim_test.go
@@ -249,7 +249,7 @@ func TestClaimMixedPool_PersonAndDept(t *testing.T) {
 	taskID := e.pendingClaimTaskID(instID)
 
 	require.NoError(t, e.engine.GetTaskService().AddCandidates(
-		e.userCtx("eve"), service.Actor{UserID: "eve", TenantID: e2eTenantID},
+		e.userCtx("admin"), adminActor(),
 		taskID, string(enums.EntityTypePerson), []string{"carol"}),
 		"追加 person 候选")
 

--- a/test/e2e/runtime_ops_test.go
+++ b/test/e2e/runtime_ops_test.go
@@ -27,8 +27,10 @@ import (
 )
 
 // adminActor 运维接口测试用的管理员身份（与 e2e 租户一致）。
+// SuperAdmin 置位：终止/重启/强恢复/重驱动/救援等实例级运维操作现要求属主或管理员，
+// e2e 以"admin"作为运营管理员驱动这些接口。
 func adminActor() service.Actor {
-	return service.Actor{UserID: "admin", UserName: "admin", TenantID: e2eTenantID}
+	return service.Actor{UserID: "admin", UserName: "admin", TenantID: e2eTenantID, SuperAdmin: true}
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
🤖 人工智能辅助贡献  
使用的工具：Deepseek Harness / deepseek v4 pro
参与程度：全部变更代码。所有代码均已人工审核并通过验证。

## 背景

审计发现变更类接口普遍只做 `ensureTenantAccess`（跨租户隔离），缺少对**属主/管理员**的校验，导致同租户任意用户拿到资源 ID 即可横向越权操作他人数据。本 PR 闭环以下三类缺口（H1 / M1 / M3）。

## 修复

### 高危 H1：候选人池无鉴权（自提权 + 跨租户写）
`service/task_service_candidates.go`
- `AddCandidates` / `RemoveCandidates` 原仅校验参数非空，直接用 `actor.TenantID` 写候选行，不校验目标任务是否存在、是否属当前租户、操作人是否管理员。
- 攻击路径：任意同租户用户 → `AddCandidates(自己)` → `Claim`(候选池命中) → 审批通过；跨租户则可污染他人任务的候选池。
- 修复：强制 `requireAdminIdentity`（管理员/系统），并校验任务存在性与 `task.TenantID == actor.TenantID`（跨租户按 `ErrNotFound` 隐藏存在性）。

### 中 M1：SetPriority / SetDueDate 无归属校验
`service/task_service_status.go`
- 原仅做租户校验，任意同租户用户可改写他人任务优先级/截止时间。
- 修复：新增 `requireTaskOperatorAuthorized`（assignee / 管理员 / 系统三选一，fail-closed），对齐同文件 Suspend/Activate 的 assignee 校验。

### 中 M3：实例生命周期缺属主/管理员校验
`service/runtime_service_impl.go`
- 原 `Terminate / Suspend / Delete / Activate(恢复) / Restart / ForceResume / ReDrive / RescueExpiredDelayTask` 均只 `ensureTenantAccess`，任意同租户用户可终止/挂起/删除/重启他人运行中的实例。
- 修复：统一新增 `requireInstanceOwnerAuthorized`（发起人 / 管理员 / 系统三选一），镜像 `withdrawInternal` 的属主规则。

## 关键设计：引擎内部级联不被误伤

失败终止（`handleProcessInstanceFailure`）与驳回级联终止（`terminateInstance`）携带的是**参与该实例的真实用户**（审批人/驳回人）而非发起人，属流程语义驱动的副作用，不能套用属主规则。

- `requireInstanceOwnerAuthorized` 对 `CallingModeInternal` 直接放行（租户校验仍照常执行）。
- 补齐 `components/node_topology.go` 中 `terminateInstance` 的 `WithInternalCallingMode` 标记，与 `handleProcessInstanceFailure` 保持一致；驳回/失败级联终止不因属主校验被误拦截。

## 新增/更新

- 新增 `service/operator_authz.go`：`requireInstanceOwnerAuthorized` / `requireTaskOperatorAuthorized`。
- 新增 `service/operator_authz_test.go`：两个助手的表驱动单测（属主/管理员/系统/内部级联/空操作人/空发起人等边界）。
- 新增 `TestAddCandidates_Authz`：非管理员拒绝 / 跨租户 NotFound / 管理员同租户放行。
- 更新受影响既有用例：
  - `delay_rescue_test.go`、`runtime_ops_test.go`：运维 actor 以 `SuperAdmin: true` 标记（终止/重启/强恢复/重驱动/救援现要求属主或管理员）。
  - `task_event_dispatch_test.go`：admin 操作人补 `SuperAdmin`。
  - `runtime_lifecycle_guard_test.go`：直接调用内部 API `TerminateInTx` 的用例标记 `WithInternalCallingMode`。
  - `test/e2e/candidate_claim_test.go`：`AddCandidates` 手动加候选改用管理员身份。

## 验证

- `gofmt` 无告警；`go vet ./...` 通过。
- `go test ./...` 全绿（退出码 0）。