### PR TITLE
fix(service): 读路径补租户作用域，堵住 IDOR 与空租户 fail-open

### DIFF
--- a/service/delay_rescue_test.go
+++ b/service/delay_rescue_test.go
@@ -129,7 +129,7 @@ func TestGetExpiredDelayTasks_Filters(t *testing.T) {
 	require.NoError(t, dao.NewTaskDAOWithQuery(q).Update(context.Background(),
 		&model.WfTask{ID: "t-other-tenant", TenantID: "t2"}))
 
-	got, err := rs.GetExpiredDelayTasks(context.Background(), "t1")
+	got, err := rs.GetExpiredDelayTasks(context.Background(), Actor{UserID: "admin", UserName: "admin", TenantID: "t1", SuperAdmin: true})
 	require.NoError(t, err)
 	ids := make([]string, 0, len(got))
 	for _, task := range got {
@@ -137,10 +137,17 @@ func TestGetExpiredDelayTasks_Filters(t *testing.T) {
 	}
 	assert.ElementsMatch(t, []string{"t-expired", "t-expired-active"}, ids)
 
-	// 空租户 = 全租户视角
-	all, err := rs.GetExpiredDelayTasks(context.Background(), "")
+	// 系统身份 + 空租户 = 平台级全租户视角
+	all, err := rs.GetExpiredDelayTasks(context.Background(), SystemActor())
 	require.NoError(t, err)
 	assert.Len(t, all, 3)
+
+	// 非管理员/非系统身份被拒（横向越权防护）
+	_, err = rs.GetExpiredDelayTasks(context.Background(), Actor{UserID: "eve", TenantID: "t1"})
+	require.ErrorIs(t, err, ErrPermissionDenied)
+	// 管理员但空租户被拒（管理员仅能巡本租户，跨租户巡检仅限系统身份）
+	_, err = rs.GetExpiredDelayTasks(context.Background(), Actor{UserID: "admin", SuperAdmin: true})
+	require.ErrorIs(t, err, ErrValidation)
 }
 
 // 参数与状态守卫：空 ID / 不存在 / 非 delay / 已终态 / 未到期 / 实例非 active /

--- a/service/history_service_impl.go
+++ b/service/history_service_impl.go
@@ -44,6 +44,9 @@ func NewHistoryServiceWithQuery(q *query.Query) HistoryService {
 // GetHistoricProcessInstances 获取历史流程实例列表
 func (s *HistoryServiceImpl) GetHistoricProcessInstances(ctx context.Context, actor Actor, query *HistoricProcessInstanceQuery) ([]*HistoricProcessInstance, int64, error) {
 	ctx = bindActor(ctx, actor)
+	if err := requireNonEmptyTenantForRealUser(&actor); err != nil {
+		return nil, 0, err
+	}
 	if query == nil {
 		query = &HistoricProcessInstanceQuery{}
 	}
@@ -86,11 +89,8 @@ func (s *HistoryServiceImpl) GetHistoricProcessInstances(ctx context.Context, ac
 		}
 	}
 
-	instanceQuery.TenantID = query.TenantID
-	// 强制以 actor 租户为查询范围；空租户视为系统视角，不做租户过滤
-	if u := GetUserFromCtx(ctx); u != nil && u.TenantID != "" {
-		instanceQuery.TenantID = u.TenantID
-	}
+	// 强制以 actor 租户为查询范围：系统身份空租户＝平台级扫描，非系统空租户 fail-closed。
+	instanceQuery.TenantID = actor.TenantID
 	instances, total, err := s.hiInstanceDAO.List(ctx, instanceQuery)
 	if err != nil {
 		return nil, 0, fmt.Errorf("failed to query historic process instances: %w", err)
@@ -137,6 +137,9 @@ func (s *HistoryServiceImpl) GetHistoricProcessInstance(ctx context.Context, act
 // GetHistoricTaskInstances 获取历史任务实例列表
 func (s *HistoryServiceImpl) GetHistoricTaskInstances(ctx context.Context, actor Actor, query *HistoricTaskInstanceQuery) ([]*HistoricTaskInstance, int64, error) {
 	ctx = bindActor(ctx, actor)
+	if err := requireNonEmptyTenantForRealUser(&actor); err != nil {
+		return nil, 0, err
+	}
 	if query == nil {
 		query = &HistoricTaskInstanceQuery{}
 	}
@@ -156,7 +159,7 @@ func (s *HistoryServiceImpl) GetHistoricTaskInstances(ctx context.Context, actor
 		Name:        query.TaskName,
 		Assignee:    query.TaskAssignee,
 		Owner:       query.TaskOwner,
-		TenantID:    query.TenantID,
+		TenantID:    actor.TenantID,
 		// 完成时间窗 → EndedAfter/Before；创建时间窗 → CreatedAfter/Before
 		EndedAfter:    query.TaskCompletedAfter,
 		EndedBefore:   query.TaskCompletedBefore,
@@ -168,11 +171,6 @@ func (s *HistoryServiceImpl) GetHistoricTaskInstances(ctx context.Context, actor
 			OrderBy:   query.OrderBy,
 			OrderDesc: strings.EqualFold(query.SortOrder, "desc"),
 		},
-	}
-
-	// 强制以 actor 租户为查询范围；空租户视为系统视角，不做租户过滤
-	if u := GetUserFromCtx(ctx); u != nil && u.TenantID != "" {
-		taskQuery.TenantID = u.TenantID
 	}
 
 	// 查询任务

--- a/service/identity.go
+++ b/service/identity.go
@@ -66,6 +66,34 @@ func requireAdminIdentity(actor *Actor) error {
 	return fmt.Errorf("operation requires admin or system identity: %w", ErrPermissionDenied)
 }
 
+// requireInspectionTenant 校验巡检端点（卡死实例/超期 delay 任务）的操作人身份，
+// 返回巡检租户。仅管理员（SuperAdmin）或系统身份可巡；系统身份空租户＝平台级
+// 全租户扫描（定时巡检跨租户是设计内行为），非系统身份必须携带本租户，杜绝
+// 调用方自定裸 tenantID 越权扫其它租户（原形参 tenantID 为空即全租户）。
+func requireInspectionTenant(actor *Actor) (string, error) {
+	if err := requireAdminIdentity(actor); err != nil {
+		return "", err
+	}
+	if !IsSystemActor(actor) && actor.TenantID == "" {
+		return "", fmt.Errorf("tenant ID required for non-system inspection: %w", ErrValidation)
+	}
+	return actor.TenantID, nil
+}
+
+// requireNonEmptyTenantForRealUser 对非系统身份的空租户 fail-closed。列表/批量只读
+// DAO 遇空租户会跳过租户过滤退化为跨租户全量（与单读 ensureTenantAccess 的空租户
+// 拒绝不一致），故真实用户必须携带租户；系统身份空租户放行（平台级巡检/管理视角
+// 跨租户扫描是设计内行为）。
+func requireNonEmptyTenantForRealUser(actor *Actor) error {
+	if actor == nil {
+		return fmt.Errorf("operator identity required: %w", ErrAuthenticationRequired)
+	}
+	if !IsSystemActor(actor) && actor.TenantID == "" {
+		return fmt.Errorf("tenant ID required: %w", ErrValidation)
+	}
+	return nil
+}
+
 // ActorFromCtx 取 ctx 已绑定操作人，未绑定返回 SystemActor。
 // 供引擎内部回调（aspect/节点/级联）使用，保留原身份可维持租户校验与事件归属。
 func ActorFromCtx(ctx context.Context) Actor {

--- a/service/process_service_impl.go
+++ b/service/process_service_impl.go
@@ -269,15 +269,16 @@ func (s *ProcessServiceImpl) create(ctx context.Context, process *model.WfProces
 }
 
 // List 分页查询流程定义列表。
-// 强制以 actor 租户为查询范围；空租户视为系统视角，不做租户过滤。
+// 强制以 actor 租户为查询范围：系统身份空租户＝平台级扫描，非系统空租户 fail-closed。
 func (s *ProcessServiceImpl) List(ctx context.Context, actor Actor, request *dto.ProcessQueryRequest) ([]*model.WfProcess, int64, error) {
 	ctx = bindActor(ctx, actor)
 	if request == nil {
 		request = &dto.ProcessQueryRequest{}
 	}
-	if u := GetUserFromCtx(ctx); u != nil && u.TenantID != "" {
-		request.TenantID = u.TenantID
+	if err := requireNonEmptyTenantForRealUser(&actor); err != nil {
+		return nil, 0, err
 	}
+	request.TenantID = actor.TenantID
 	return s.processDAO.List(ctx, request)
 }
 

--- a/service/runtime_service.go
+++ b/service/runtime_service.go
@@ -59,11 +59,13 @@ type RuntimeService interface {
 	// UpdateInstanceCurrentActivity 更新 active 实例的当前节点（userTask 创建任务时由节点回调）
 	UpdateInstanceCurrentActivity(ctx context.Context, processInstanceID, activityKey string) error
 
-	// GetStuckProcessInstances 找出 active 但无未决任务的卡死实例（对账巡检/管理端救援）
-	GetStuckProcessInstances(ctx context.Context, tenantID string) ([]*model.WfInstance, error)
+	// GetStuckProcessInstances 找出 active 但无未决任务的卡死实例（对账巡检/管理端救援）。
+	// 仅管理员/系统身份可巡，租户取自操作人（系统空租户＝平台级全租户扫描）。
+	GetStuckProcessInstances(ctx context.Context, actor Actor) ([]*model.WfInstance, error)
 
-	// GetExpiredDelayTasks 找出超期未完成的 delay 任务（计时器丢失检测）
-	GetExpiredDelayTasks(ctx context.Context, tenantID string) ([]*model.WfTask, error)
+	// GetExpiredDelayTasks 找出超期未完成的 delay 任务（计时器丢失检测）。
+	// 仅管理员/系统身份可巡，租户取自操作人（系统空租户＝平台级全租户扫描）。
+	GetExpiredDelayTasks(ctx context.Context, actor Actor) ([]*model.WfTask, error)
 
 	// RescueExpiredDelayTask 救援超期的 delay 任务：携带既有 task_id 与已等待
 	// 偏移重入 delay 节点，完成后继续流转，不新建任务行。

--- a/service/runtime_service_impl.go
+++ b/service/runtime_service_impl.go
@@ -1576,7 +1576,12 @@ func (s *RuntimeServiceImpl) RestoreAllProcessInstances(ctx context.Context, act
 // 成因：审批事务已提交（任务 Completed）但 post-commit 的引擎推进失败
 // （客户端断连/DB 瞬断等）——任务没了、实例还 active、无待办可操作。
 // 本方法为对账巡检与管理端救援提供发现能力。
-func (s *RuntimeServiceImpl) GetStuckProcessInstances(ctx context.Context, tenantID string) ([]*model.WfInstance, error) {
+func (s *RuntimeServiceImpl) GetStuckProcessInstances(ctx context.Context, actor Actor) ([]*model.WfInstance, error) {
+	ctx = bindActor(ctx, actor)
+	tenantID, err := requireInspectionTenant(&actor)
+	if err != nil {
+		return nil, err
+	}
 	db := s.instanceDAO.Query.WfInstance.UnderlyingDB().WithContext(ctx)
 	q := db.Table("wf_instance as i").
 		Select("i.*").
@@ -1604,7 +1609,12 @@ const expiredDelayGracePeriod = 60 * time.Second
 // delay 计时器活在驱动它的副本进程内，副本崩溃后任务行停在未终态；due_date
 // 早于当前时间减宽限期即视为计时器丢失。引擎建的 delay 行无办理人、初始即
 // Pending，Active/Pending 一并纳入。
-func (s *RuntimeServiceImpl) GetExpiredDelayTasks(ctx context.Context, tenantID string) ([]*model.WfTask, error) {
+func (s *RuntimeServiceImpl) GetExpiredDelayTasks(ctx context.Context, actor Actor) ([]*model.WfTask, error) {
+	ctx = bindActor(ctx, actor)
+	tenantID, err := requireInspectionTenant(&actor)
+	if err != nil {
+		return nil, err
+	}
 	db := s.taskDAO.Query.WfTask.UnderlyingDB().WithContext(ctx)
 	q := db.Table("wf_task").
 		Where("task_type = ?", constants.TaskTypeDelay).
@@ -1792,10 +1802,11 @@ func (s *RuntimeServiceImpl) GetProcessInstanceList(ctx context.Context, actor A
 	if request == nil {
 		request = &dto.ProcessInstanceQueryDTO{}
 	}
-	// 强制以 actor 租户为查询范围；空租户视为系统视角，不做租户过滤
-	if u := GetUserFromCtx(ctx); u != nil && u.TenantID != "" {
-		request.TenantID = u.TenantID
+	// 强制以 actor 租户为查询范围：系统身份空租户＝平台级扫描，非系统空租户 fail-closed。
+	if err := requireNonEmptyTenantForRealUser(&actor); err != nil {
+		return nil, 0, err
 	}
+	request.TenantID = actor.TenantID
 	var (
 		instances []*model.WfInstance
 		total     int64
@@ -1824,10 +1835,11 @@ func (s *RuntimeServiceImpl) GetProcessInstanceUnionList(ctx context.Context, ac
 	if request == nil {
 		request = &dto.ProcessInstanceQueryDTO{}
 	}
-	// 强制以 actor 租户为查询范围；空租户视为系统视角，不做租户过滤
-	if u := GetUserFromCtx(ctx); u != nil && u.TenantID != "" {
-		request.TenantID = u.TenantID
+	// 强制以 actor 租户为查询范围：系统身份空租户＝平台级扫描，非系统空租户 fail-closed。
+	if err := requireNonEmptyTenantForRealUser(&actor); err != nil {
+		return nil, 0, err
 	}
+	request.TenantID = actor.TenantID
 	size := request.GetPageSize()
 	offset := (request.GetPage() - 1) * size
 	instances, total, err := s.instanceDAO.GetInstancesUnionPagination(ctx, request.TenantID, request.ProcessID, "", request.Status, request.Keyword, nil, nil, size, offset, request.InstanceID, request.BusinessKey, "")
@@ -1844,8 +1856,18 @@ func (s *RuntimeServiceImpl) UpdateInstanceCurrentActivity(ctx context.Context, 
 	return s.instanceDAO.SetCurrentActivity(ctx, processInstanceID, activityKey)
 }
 
-// GetProcessInstancesByTaskConditions 基于任务条件关联查询流程实例列表
-func (s *RuntimeServiceImpl) GetProcessInstancesByTaskConditions(ctx context.Context, req *dto.TaskQuery) ([]*model.WfInstance, int64, error) {
+// GetProcessInstancesByTaskConditions 基于任务条件关联查询流程实例列表。
+// 租户强制取自操作人 actor（而非调用方透传的 TaskQuery.TenantID），防止调用方
+// 自填/空租户透传造成跨租户数据泄露——ListByTaskConditions 对空租户不设过滤。
+func (s *RuntimeServiceImpl) GetProcessInstancesByTaskConditions(ctx context.Context, actor Actor, req *dto.TaskQuery) ([]*model.WfInstance, int64, error) {
+	ctx = bindActor(ctx, actor)
+	if req == nil {
+		return nil, 0, fmt.Errorf("task query cannot be nil")
+	}
+	if err := requireNonEmptyTenantForRealUser(&actor); err != nil {
+		return nil, 0, err
+	}
+	req.TenantID = actor.TenantID
 	return s.instanceDAO.ListByTaskConditions(ctx, req)
 }
 
@@ -1856,6 +1878,9 @@ func (s *RuntimeServiceImpl) GetProcessInstancesByTaskConditions(ctx context.Con
 // 列入过滤只会经 ListByTaskConditions 的历史分支把已结束实例捞回待办。
 func (s *RuntimeServiceImpl) GetTodoProcessInstanceList(ctx context.Context, actor Actor, page, pageSize int, keyword string, startUserIDs []string, orderBy string, orderDesc bool) ([]*model.WfInstance, int64, error) {
 	ctx = bindActor(ctx, actor)
+	if err := requireNonEmptyTenantForRealUser(&actor); err != nil {
+		return nil, 0, err
+	}
 	userID, tenantID := actor.UserID, actor.TenantID
 	q := &dto.TaskQuery{
 		Assignee:         userID,
@@ -1893,7 +1918,7 @@ func (s *RuntimeServiceImpl) isUserCandidate(ctx context.Context, task *model.Wf
 	if task == nil || task.TaskDefKey == "" || task.ProcessInstanceID == nil || *task.ProcessInstanceID == "" || userID == "" {
 		return true
 	}
-	candidates, err := s.workflowEngine.GetTaskService().GetTaskCandidates(ctx, *task.ProcessInstanceID, task.TaskDefKey)
+	candidates, err := s.workflowEngine.GetTaskService().GetTaskCandidates(ctx, ActorFromCtx(ctx), *task.ProcessInstanceID, task.TaskDefKey)
 	if err != nil {
 		// 展开失败按非候选处理（fail-closed）：与认领校验同口径，
 		// identity 不可用时不能把候选实例当空池对全租户放行。
@@ -1916,6 +1941,9 @@ func (s *RuntimeServiceImpl) isUserCandidate(ctx context.Context, task *model.Wf
 // instanceStatus 实例状态筛选桶（active/completed/rejected/withdrawn），空为不过滤。
 func (s *RuntimeServiceImpl) GetDoneProcessInstanceList(ctx context.Context, actor Actor, page, pageSize int, keyword string, startUserIDs []string, orderBy string, orderDesc bool, instanceStatus string) ([]*model.WfInstance, int64, error) {
 	ctx = bindActor(ctx, actor)
+	if err := requireNonEmptyTenantForRealUser(&actor); err != nil {
+		return nil, 0, err
+	}
 	userID, tenantID := actor.UserID, actor.TenantID
 	q := &dto.TaskQuery{
 		Assignee:     userID,
@@ -2014,6 +2042,9 @@ func (s *RuntimeServiceImpl) CountDoneByBuckets(ctx context.Context, actor Actor
 // GetCcProcessInstanceList 获取抄送给我的实例列表
 func (s *RuntimeServiceImpl) GetCcProcessInstanceList(ctx context.Context, actor Actor, page, pageSize int, keyword string, startUserIDs []string, orderBy string, orderDesc bool) ([]*model.WfInstance, int64, error) {
 	ctx = bindActor(ctx, actor)
+	if err := requireNonEmptyTenantForRealUser(&actor); err != nil {
+		return nil, 0, err
+	}
 	userID, tenantID := actor.UserID, actor.TenantID
 	q := &dto.TaskQuery{
 		Assignee:     userID,
@@ -2040,6 +2071,9 @@ func (s *RuntimeServiceImpl) GetCcProcessInstanceList(ctx context.Context, actor
 // GetMyApplicationsProcessInstanceList 获取我发起的申请实例列表（按 start_user_id=发起人用户ID 过滤，与 token userId 同口径）
 func (s *RuntimeServiceImpl) GetMyApplicationsProcessInstanceList(ctx context.Context, actor Actor, page, pageSize int, keyword, orderBy string, orderDesc bool, instanceStatus string) ([]*model.WfInstance, int64, error) {
 	ctx = bindActor(ctx, actor)
+	if err := requireNonEmptyTenantForRealUser(&actor); err != nil {
+		return nil, 0, err
+	}
 	userID, tenantID := actor.UserID, actor.TenantID
 	if page <= 0 {
 		page = 1

--- a/service/runtime_service_impl_test.go
+++ b/service/runtime_service_impl_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/rulego/gflow-engine/dao"
 	"github.com/rulego/gflow-engine/model"
 	"github.com/rulego/gflow-engine/query"
+	"github.com/rulego/gflow-engine/types/dto"
 	"github.com/rulego/gflow-engine/types/enums"
 )
 
@@ -245,8 +246,25 @@ func TestRuntimeServiceImpl_ExecuteNext_NilDAO_Panics(t *testing.T) {
 func TestRuntimeServiceImpl_GetProcessInstanceList_NilDAO_Panics(t *testing.T) {
 	s := &RuntimeServiceImpl{}
 	expectPanicRuntime(t, "GetProcessInstanceList", func() {
-		s.GetProcessInstanceList(context.Background(), Actor{}, nil)
+		s.GetProcessInstanceList(context.Background(), Actor{UserID: "u1", TenantID: "t1"}, nil)
 	})
+}
+
+// 空租户的真实用户列表查询应 fail-closed（不再退化为跨租户全量），不会触达 DAO。
+func TestRuntimeServiceImpl_GetProcessInstanceList_EmptyTenantDenied(t *testing.T) {
+	s := &RuntimeServiceImpl{}
+	_, _, err := s.GetProcessInstanceList(context.Background(), Actor{UserID: "u1"}, nil)
+	require.ErrorIs(t, err, ErrValidation)
+}
+
+// GetProcessInstancesByTaskConditions 的入口守卫：nil 请求明确报错；非系统空租户
+// fail-closed（不再透传调用方 TaskQuery.TenantID 造成跨租户）。
+func TestRuntimeServiceImpl_GetProcessInstancesByTaskConditions_Guards(t *testing.T) {
+	s := &RuntimeServiceImpl{}
+	_, _, err := s.GetProcessInstancesByTaskConditions(context.Background(), Actor{UserID: "u1", TenantID: "t1"}, nil)
+	require.Error(t, err)
+	_, _, err = s.GetProcessInstancesByTaskConditions(context.Background(), Actor{UserID: "u1"}, &dto.TaskQuery{})
+	require.ErrorIs(t, err, ErrValidation)
 }
 
 // ---------------------------------------------------------------------------

--- a/service/task_service.go
+++ b/service/task_service.go
@@ -94,8 +94,8 @@ type TaskService interface {
 	// GetTaskByDefKey 按实例+节点定义Key取当前任务（同 key 多行时取第一条）
 	GetTaskByDefKey(ctx context.Context, processInstanceID, taskDefKey string) (*model.WfTask, error)
 
-	// GetTaskCandidates 获取任务候选人
-	GetTaskCandidates(ctx context.Context, processInstanceID, taskDefKey string) ([]*dto.NodeApproverDTO, error)
+	// GetTaskCandidates 获取任务候选人（actor 含租户时做任务归属校验，跨租户拒绝）
+	GetTaskCandidates(ctx context.Context, actor Actor, processInstanceID, taskDefKey string) ([]*dto.NodeApproverDTO, error)
 
 	// AddCandidates 批量写入任务候选人（存原始角色/部门/person 引用，查询时展开）。
 	// 每条 entityID 一条 wf_task_assignee 记录。
@@ -209,14 +209,14 @@ type TaskService interface {
 
 	// ========== 节点审批人管理 ==========
 
-	// GetNodeApprovalStatus 获取节点审批状态信息
-	GetNodeApprovalStatus(ctx context.Context, taskID string) (*dto.NodeApprovalStatusDTO, error)
+	// GetNodeApprovalStatus 获取节点审批状态信息（actor 含租户时做任务归属校验，跨租户拒绝）
+	GetNodeApprovalStatus(ctx context.Context, actor Actor, taskID string) (*dto.NodeApprovalStatusDTO, error)
 
 	// GetNodeApprovers 获取节点审批人列表
-	GetNodeApprovers(ctx context.Context, taskID string) ([]*dto.NodeApproverDTO, error)
+	GetNodeApprovers(ctx context.Context, actor Actor, taskID string) ([]*dto.NodeApproverDTO, error)
 
 	// GetNodeApprovalStatusByProcessInstance 根据流程实例和任务定义Key获取节点审批状态
-	GetNodeApprovalStatusByProcessInstance(ctx context.Context, processInstanceID, taskDefKey string) (*dto.NodeApprovalStatusDTO, error)
+	GetNodeApprovalStatusByProcessInstance(ctx context.Context, actor Actor, processInstanceID, taskDefKey string) (*dto.NodeApprovalStatusDTO, error)
 }
 
 // TaskServiceInternal 引擎内部机制使用的任务服务接口，宿主不应调用。

--- a/service/task_service_candidates.go
+++ b/service/task_service_candidates.go
@@ -83,8 +83,10 @@ func (s *TaskServiceImpl) collectCandidateMembersExcluding(ctx context.Context, 
 }
 
 // GetTaskCandidates 获取任务候选人：读 wf_task_assignee 展开 role/dept 候选。
-// tenantID 从查询的实例/任务上无法可靠拿到，这里按实例内任意一条任务取 tenantID（同实例同节点任务租户一致）。
-func (s *TaskServiceImpl) GetTaskCandidates(ctx context.Context, processInstanceID, taskDefKey string) ([]*dto.NodeApproverDTO, error) {
+// tenantID 从实例/任务推断，并校验调用方租户（跨租户拒绝），防止候选人名单
+// IDOR 泄露审批人员身份。
+func (s *TaskServiceImpl) GetTaskCandidates(ctx context.Context, actor Actor, processInstanceID, taskDefKey string) ([]*dto.NodeApproverDTO, error) {
+	ctx = bindActor(ctx, actor)
 	if taskDefKey == "" || processInstanceID == "" {
 		return nil, fmt.Errorf("taskDefKey and processInstanceID cannot be empty")
 	}
@@ -102,6 +104,12 @@ func (s *TaskServiceImpl) GetTaskCandidates(ctx context.Context, processInstance
 	tenantID := ""
 	if len(tasks) > 0 {
 		tenantID = tasks[0].TenantID
+	}
+	// 租户校验：任务存在时按调用方租户拦截跨租户读取（IDOR 防护）。
+	if tenantID != "" {
+		if err := ensureTenantAccess(ctx, "task", tenantID); err != nil {
+			return nil, err
+		}
 	}
 
 	rows, err := s.taskAssigneeDAO.GetByInstanceAndDefKey(ctx, tenantID, processInstanceID, taskDefKey)
@@ -244,7 +252,8 @@ func nodeApproverFromTask(t *model.WfTask, status string, approvalTime *string, 
 }
 
 // GetNodeApprovalStatus 获取节点审批状态（已审批/待审批名单及审批规则摘要）。
-func (s *TaskServiceImpl) GetNodeApprovalStatus(ctx context.Context, taskID string) (*dto.NodeApprovalStatusDTO, error) {
+func (s *TaskServiceImpl) GetNodeApprovalStatus(ctx context.Context, actor Actor, taskID string) (*dto.NodeApprovalStatusDTO, error) {
+	ctx = bindActor(ctx, actor)
 	if taskID == "" {
 		return nil, fmt.Errorf("taskID cannot be empty")
 	}
@@ -255,6 +264,10 @@ func (s *TaskServiceImpl) GetNodeApprovalStatus(ctx context.Context, taskID stri
 	}
 	if task == nil {
 		return nil, fmt.Errorf("%w: task", ErrNotFound)
+	}
+	// 租户校验：跨租户读取节点审批人名单按拒绝处理（IDOR 防护）
+	if err := ensureTenantAccess(ctx, "task", task.TenantID); err != nil {
+		return nil, err
 	}
 	// orphan/draft 任务没有实例，节点审批状态无从谈起
 	if task.ProcessInstanceID == nil || *task.ProcessInstanceID == "" {
@@ -306,7 +319,7 @@ func (s *TaskServiceImpl) GetNodeApprovalStatus(ctx context.Context, taskID stri
 	// 候选任务（未 claim，无 assignee）：PendingList 用展开后的候选成员展示。
 	if task.Assignee == nil || *task.Assignee == "" {
 		if task.ProcessInstanceID != nil && *task.ProcessInstanceID != "" && task.TaskDefKey != "" {
-			if candidates, cErr := s.GetTaskCandidates(ctx, *task.ProcessInstanceID, task.TaskDefKey); cErr == nil {
+			if candidates, cErr := s.GetTaskCandidates(ctx, actor, *task.ProcessInstanceID, task.TaskDefKey); cErr == nil {
 				for _, c := range candidates {
 					if c == nil || c.EntityID == "" {
 						continue
@@ -343,8 +356,8 @@ func (s *TaskServiceImpl) GetNodeApprovalStatus(ctx context.Context, taskID stri
 }
 
 // GetNodeApprovers 获取节点审批人列表（已审批 + 待审批合并）。
-func (s *TaskServiceImpl) GetNodeApprovers(ctx context.Context, taskID string) ([]*dto.NodeApproverDTO, error) {
-	status, err := s.GetNodeApprovalStatus(ctx, taskID)
+func (s *TaskServiceImpl) GetNodeApprovers(ctx context.Context, actor Actor, taskID string) ([]*dto.NodeApproverDTO, error) {
+	status, err := s.GetNodeApprovalStatus(ctx, actor, taskID)
 	if err != nil {
 		return nil, err
 	}
@@ -357,7 +370,8 @@ func (s *TaskServiceImpl) GetNodeApprovers(ctx context.Context, taskID string) (
 }
 
 // GetNodeApprovalStatusByProcessInstance 根据流程实例和任务定义Key获取节点审批状态。
-func (s *TaskServiceImpl) GetNodeApprovalStatusByProcessInstance(ctx context.Context, processInstanceID, taskDefKey string) (*dto.NodeApprovalStatusDTO, error) {
+func (s *TaskServiceImpl) GetNodeApprovalStatusByProcessInstance(ctx context.Context, actor Actor, processInstanceID, taskDefKey string) (*dto.NodeApprovalStatusDTO, error) {
+	ctx = bindActor(ctx, actor)
 	if processInstanceID == "" || taskDefKey == "" {
 		return nil, fmt.Errorf("processInstanceID and taskDefKey cannot be empty")
 	}
@@ -380,5 +394,10 @@ func (s *TaskServiceImpl) GetNodeApprovalStatusByProcessInstance(ctx context.Con
 		return nil, fmt.Errorf("%w: no active task for process instance %s and task def key %s", ErrNotFound, processInstanceID, taskDefKey)
 	}
 
-	return s.GetNodeApprovalStatus(ctx, tasks[0].ID)
+	// 租户校验：跨租户读取节点审批状态按拒绝处理（IDOR 防护）。
+	if err := ensureTenantAccess(ctx, "task", tasks[0].TenantID); err != nil {
+		return nil, err
+	}
+
+	return s.GetNodeApprovalStatus(ctx, actor, tasks[0].ID)
 }

--- a/service/task_service_candidates_test.go
+++ b/service/task_service_candidates_test.go
@@ -274,7 +274,7 @@ func TestGetTaskCandidates_RoleExpanded(t *testing.T) {
 	taskSvc := newCandSvc(q, identity)
 	require.NoError(t, taskSvc.AddCandidates(ctx, Actor{UserID: "system", TenantID: "t1"}, "task-cand", "role", []string{"role-a"}))
 
-	candidates, err := taskSvc.GetTaskCandidates(ctx, "inst-cand", "approve-node")
+	candidates, err := taskSvc.GetTaskCandidates(ctx, Actor{UserID: "tester", TenantID: "t1"}, "inst-cand", "approve-node")
 	require.NoError(t, err)
 	require.NotEmpty(t, candidates, "role 任务候选展开后应非空")
 
@@ -298,15 +298,43 @@ func TestGetTaskCandidates_IdentityNil(t *testing.T) {
 	require.NoError(t, taskSvc.AddCandidates(ctx, Actor{UserID: "system", TenantID: "t1"}, "task-mix", "role", []string{"role-a"}))
 	require.NoError(t, taskSvc.AddCandidates(ctx, Actor{UserID: "system", TenantID: "t1"}, "task-mix", "person", []string{"p1"}))
 
-	_, err := taskSvc.GetTaskCandidates(ctx, "inst-mix", "approve-node")
+	_, err := taskSvc.GetTaskCandidates(ctx, Actor{UserID: "tester", TenantID: "t1"}, "inst-mix", "approve-node")
 	require.Error(t, err, "identity 缺失且池含 role 实体时必须报错")
 
 	require.NoError(t, taskSvc.RemoveCandidates(ctx, Actor{UserID: "system", TenantID: "t1"}, "task-mix", "role", []string{"role-a"}))
-	candidates, err := taskSvc.GetTaskCandidates(ctx, "inst-mix", "approve-node")
+	candidates, err := taskSvc.GetTaskCandidates(ctx, Actor{UserID: "tester", TenantID: "t1"}, "inst-mix", "approve-node")
 	require.NoError(t, err)
 	require.Len(t, candidates, 1, "纯 person 池不依赖 identity")
 	require.Equal(t, "p1", candidates[0].EntityID)
 	require.Equal(t, "person", candidates[0].EntityType)
+}
+
+// TestGetTaskCandidates_CrossTenantDenied 验证候选人读取的租户作用域：跨租户与
+// 空租户真实用户均被拒（不泄露候选人/审批人身份）。
+func TestGetTaskCandidates_CrossTenantDenied(t *testing.T) {
+	q := candGroupDB(t)
+	ctx := context.Background()
+	seedRoleInstance(t, q, "task-cand", "inst-cand")
+	taskSvc := newCandSvc(q, newMockIdentity())
+
+	_, err := taskSvc.GetTaskCandidates(ctx, Actor{UserID: "eve", TenantID: "other"}, "inst-cand", "approve-node")
+	require.ErrorIs(t, err, ErrPermissionDenied)
+	_, err = taskSvc.GetTaskCandidates(ctx, Actor{UserID: "eve"}, "inst-cand", "approve-node")
+	require.ErrorIs(t, err, ErrPermissionDenied)
+}
+
+// TestGetNodeApprovalStatus_CrossTenantDenied 验证节点审批状态读取的租户作用域：
+// 跨租户与空租户真实用户按拒绝处理，不泄露审批人身份。
+func TestGetNodeApprovalStatus_CrossTenantDenied(t *testing.T) {
+	q := candGroupDB(t)
+	ctx := context.Background()
+	seedRoleInstance(t, q, "task-cand", "inst-cand")
+	taskSvc := newCandSvc(q, newMockIdentity())
+
+	_, err := taskSvc.GetNodeApprovalStatus(ctx, Actor{UserID: "eve", TenantID: "other"}, "task-cand")
+	require.ErrorIs(t, err, ErrPermissionDenied)
+	_, err = taskSvc.GetNodeApprovalStatus(ctx, Actor{UserID: "eve"}, "task-cand")
+	require.ErrorIs(t, err, ErrPermissionDenied)
 }
 
 // TestGetClaimableInstanceIDs 批量判断可认领实例：

--- a/service/task_service_comment.go
+++ b/service/task_service_comment.go
@@ -69,7 +69,7 @@ func (s *TaskServiceImpl) GetTaskComments(ctx context.Context, actor Actor, task
 	if err != nil {
 		return nil, err
 	}
-	if u := GetUserFromCtx(ctx); u != nil && u.TenantID != "" && task.TenantID != u.TenantID {
+	if u := GetUserFromCtx(ctx); u != nil && !IsSystemActor(u) && task.TenantID != u.TenantID {
 		return nil, fmt.Errorf("%w: task", ErrNotFound)
 	}
 	return s.taskCommentDAO.ListByTaskID(ctx, taskID)

--- a/service/task_service_history.go
+++ b/service/task_service_history.go
@@ -38,10 +38,10 @@ func (s *TaskServiceImpl) GetTaskByDefKey(ctx context.Context, processInstanceID
 	if len(tasks) == 0 {
 		return nil, nil
 	}
-	// 租户校验：ctx 用户租户非空时任务必须同租户，否则按 NotFound 处理
-	// （不泄露存在性），与 GetHistoryTask 同口径
+	// 租户校验：非系统操作人必须与任务同租户（真实用户空租户 fail-closed），否则按
+	// NotFound 处理（不泄露存在性），与 GetHistoryTask 同口径
 	task := tasks[0]
-	if u := GetUserFromCtx(ctx); u != nil && u.TenantID != "" && task.TenantID != u.TenantID {
+	if u := GetUserFromCtx(ctx); u != nil && !IsSystemActor(u) && task.TenantID != u.TenantID {
 		return nil, fmt.Errorf("%w: task", ErrNotFound)
 	}
 	return task, nil

--- a/service/task_service_impl_test.go
+++ b/service/task_service_impl_test.go
@@ -307,7 +307,7 @@ func TestTaskServiceImpl_GetApprovalStatisticsDetail_EmptyUserID(t *testing.T) {
 
 func TestTaskServiceImpl_GetNodeApprovalStatus_EmptyTaskID(t *testing.T) {
 	s := newTaskServiceImplForTest()
-	_, err := s.GetNodeApprovalStatus(context.Background(), "")
+	_, err := s.GetNodeApprovalStatus(context.Background(), Actor{TenantID: "t1"}, "")
 	if err == nil {
 		t.Error("expected error for empty taskID")
 	}
@@ -315,7 +315,7 @@ func TestTaskServiceImpl_GetNodeApprovalStatus_EmptyTaskID(t *testing.T) {
 
 func TestTaskServiceImpl_GetNodeApprovers_EmptyTaskID(t *testing.T) {
 	s := newTaskServiceImplForTest()
-	_, err := s.GetNodeApprovers(context.Background(), "")
+	_, err := s.GetNodeApprovers(context.Background(), Actor{TenantID: "t1"}, "")
 	if err == nil {
 		t.Error("expected error for empty taskID")
 	}
@@ -323,7 +323,7 @@ func TestTaskServiceImpl_GetNodeApprovers_EmptyTaskID(t *testing.T) {
 
 func TestTaskServiceImpl_GetNodeApprovalStatusByProcessInstance_EmptyID(t *testing.T) {
 	s := newTaskServiceImplForTest()
-	_, err := s.GetNodeApprovalStatusByProcessInstance(context.Background(), "", "key1")
+	_, err := s.GetNodeApprovalStatusByProcessInstance(context.Background(), Actor{TenantID: "t1"}, "", "key1")
 	if err == nil {
 		t.Error("expected error for empty processInstanceID")
 	}
@@ -331,7 +331,7 @@ func TestTaskServiceImpl_GetNodeApprovalStatusByProcessInstance_EmptyID(t *testi
 
 func TestTaskServiceImpl_GetNodeApprovalStatusByProcessInstance_EmptyKey(t *testing.T) {
 	s := newTaskServiceImplForTest()
-	_, err := s.GetNodeApprovalStatusByProcessInstance(context.Background(), "inst1", "")
+	_, err := s.GetNodeApprovalStatusByProcessInstance(context.Background(), Actor{TenantID: "t1"}, "inst1", "")
 	if err == nil {
 		t.Error("expected error for empty taskDefKey")
 	}
@@ -466,7 +466,7 @@ func TestGetHistoryTask_EmptyID(t *testing.T) {
 
 func TestGetTaskCandidates_EmptyDefKey(t *testing.T) {
 	s := newTaskServiceForValidation()
-	_, err := s.GetTaskCandidates(context.Background(), "inst1", "")
+	_, err := s.GetTaskCandidates(context.Background(), Actor{TenantID: "t1"}, "inst1", "")
 	if err == nil {
 		t.Error("expected error for empty taskDefKey")
 	}
@@ -474,7 +474,7 @@ func TestGetTaskCandidates_EmptyDefKey(t *testing.T) {
 
 func TestGetTaskCandidates_EmptyInstanceID(t *testing.T) {
 	s := newTaskServiceForValidation()
-	_, err := s.GetTaskCandidates(context.Background(), "", "key1")
+	_, err := s.GetTaskCandidates(context.Background(), Actor{TenantID: "t1"}, "", "key1")
 	if err == nil {
 		t.Error("expected error for empty processInstanceID")
 	}
@@ -658,7 +658,7 @@ func TestReturn_EmptyUserID(t *testing.T) {
 
 func TestGetNodeApprovalStatus_EmptyID(t *testing.T) {
 	s := newTaskServiceForValidation()
-	_, err := s.GetNodeApprovalStatus(context.Background(), "")
+	_, err := s.GetNodeApprovalStatus(context.Background(), Actor{TenantID: "t1"}, "")
 	if err == nil {
 		t.Error("expected error for empty taskID")
 	}
@@ -666,7 +666,7 @@ func TestGetNodeApprovalStatus_EmptyID(t *testing.T) {
 
 func TestGetNodeApprovalStatusByProcessInstance_EmptyInstanceID(t *testing.T) {
 	s := newTaskServiceForValidation()
-	_, err := s.GetNodeApprovalStatusByProcessInstance(context.Background(), "", "key1")
+	_, err := s.GetNodeApprovalStatusByProcessInstance(context.Background(), Actor{TenantID: "t1"}, "", "key1")
 	if err == nil {
 		t.Error("expected error for empty processInstanceID")
 	}
@@ -674,7 +674,7 @@ func TestGetNodeApprovalStatusByProcessInstance_EmptyInstanceID(t *testing.T) {
 
 func TestGetNodeApprovalStatusByProcessInstance_EmptyDefKey(t *testing.T) {
 	s := newTaskServiceForValidation()
-	_, err := s.GetNodeApprovalStatusByProcessInstance(context.Background(), "inst1", "")
+	_, err := s.GetNodeApprovalStatusByProcessInstance(context.Background(), Actor{TenantID: "t1"}, "inst1", "")
 	if err == nil {
 		t.Error("expected error for empty taskDefKey")
 	}

--- a/service/task_service_statistics.go
+++ b/service/task_service_statistics.go
@@ -27,10 +27,11 @@ func (s *TaskServiceImpl) GetTaskList(ctx context.Context, actor Actor, query *d
 	if query == nil {
 		query = &dto.TaskQuery{}
 	}
-	// 强制以 actor 租户为查询范围；空租户视为系统视角，不做租户过滤
-	if u := GetUserFromCtx(ctx); u != nil && u.TenantID != "" {
-		query.TenantID = u.TenantID
+	// 强制以 actor 租户为查询范围：系统身份空租户＝平台级扫描，非系统空租户 fail-closed。
+	if err := requireNonEmptyTenantForRealUser(&actor); err != nil {
+		return nil, 0, err
 	}
+	query.TenantID = actor.TenantID
 	// QueryTasks 处理 nil query 与历史表路由，避免这里解引用空指针
 	return s.QueryTasks(ctx, query)
 }

--- a/service/task_service_variables.go
+++ b/service/task_service_variables.go
@@ -30,8 +30,9 @@ func (s *TaskServiceImpl) GetTaskVariables(ctx context.Context, actor Actor, tas
 		return nil, fmt.Errorf("%w: task", ErrNotFound)
 	}
 
-	// 租户校验：actor 租户非空时任务必须同租户（跨租户按不存在处理，不泄露任务存在性）
-	if u := GetUserFromCtx(ctx); u != nil && u.TenantID != "" && task.TenantID != u.TenantID {
+	// 租户校验：非系统操作人必须与任务同租户（真实用户空租户 fail-closed；系统身份/
+	// 无身份放行），跨租户按不存在处理，不泄露任务存在性。
+	if u := GetUserFromCtx(ctx); u != nil && !IsSystemActor(u) && task.TenantID != u.TenantID {
 		return nil, fmt.Errorf("%w: task", ErrNotFound)
 	}
 

--- a/service/testutil_test.go
+++ b/service/testutil_test.go
@@ -58,10 +58,10 @@ func (r *testRuntimeDouble) GetProcessInstanceUnionList(ctx context.Context, act
 func (r *testRuntimeDouble) UpdateInstanceCurrentActivity(ctx context.Context, id, activityKey string) error {
 	return nil
 }
-func (r *testRuntimeDouble) GetStuckProcessInstances(ctx context.Context, tenantID string) ([]*model.WfInstance, error) {
+func (r *testRuntimeDouble) GetStuckProcessInstances(ctx context.Context, actor Actor) ([]*model.WfInstance, error) {
 	return nil, nil
 }
-func (r *testRuntimeDouble) GetExpiredDelayTasks(ctx context.Context, tenantID string) ([]*model.WfTask, error) {
+func (r *testRuntimeDouble) GetExpiredDelayTasks(ctx context.Context, actor Actor) ([]*model.WfTask, error) {
 	return nil, nil
 }
 func (r *testRuntimeDouble) RescueExpiredDelayTask(ctx context.Context, actor Actor, taskID string) error {
@@ -155,7 +155,7 @@ func (r *testRuntimeDouble) CountMyApplicationsByBuckets(ctx context.Context, ac
 func (r *testRuntimeDouble) CountDoneByBuckets(ctx context.Context, actor Actor, keyword string, startUserIDs []string) (map[string]int64, error) {
 	return nil, nil
 }
-func (r *testRuntimeDouble) GetProcessInstancesByTaskConditions(ctx context.Context, req *dto.TaskQuery) ([]*model.WfInstance, int64, error) {
+func (r *testRuntimeDouble) GetProcessInstancesByTaskConditions(ctx context.Context, actor Actor, req *dto.TaskQuery) ([]*model.WfInstance, int64, error) {
 	return nil, 0, nil
 }
 func (r *testRuntimeDouble) GetProcessInstanceDetail(ctx context.Context, actor Actor, id string) (*dto.InstanceDetailResponse, error) {

--- a/test/e2e/delay_rescue_test.go
+++ b/test/e2e/delay_rescue_test.go
@@ -172,7 +172,7 @@ func TestE2E_DelayRescue_ExpiredTaskAdvancesWithoutDuplicate(t *testing.T) {
 		time.Now().Add(-2*time.Hour), time.Now().Add(-3*time.Hour), delayTaskID).Error)
 
 	// 检测：超期 delay 命中（宽限 60s，2h 前已到期）
-	expired, err := env.engine.GetRuntimeService().GetExpiredDelayTasks(env.userCtx("admin"), e2eTenantID)
+	expired, err := env.engine.GetRuntimeService().GetExpiredDelayTasks(env.userCtx("admin"), service.Actor{UserID: "admin", UserName: "admin", TenantID: e2eTenantID, SuperAdmin: true})
 	require.NoError(t, err)
 	require.Len(t, expired, 1)
 	assert.Equal(t, delayTaskID, expired[0].ID)
@@ -207,7 +207,7 @@ func TestE2E_DelayRescue_NotExpiredRejected(t *testing.T) {
 		return task != nil
 	}, 3*time.Second, 50*time.Millisecond)
 
-	expired, err := env.engine.GetRuntimeService().GetExpiredDelayTasks(env.userCtx("admin"), e2eTenantID)
+	expired, err := env.engine.GetRuntimeService().GetExpiredDelayTasks(env.userCtx("admin"), service.Actor{UserID: "admin", UserName: "admin", TenantID: e2eTenantID, SuperAdmin: true})
 	require.NoError(t, err)
 	assert.Empty(t, expired, "future delay task must not be detected as expired")
 


### PR DESCRIPTION
🤖 人工智能辅助贡献  
使用的工具：Deepseek Harness / deepseek v4 pro
参与程度：全部变更代码。所有代码均已人工审核并通过验证。

> [!WARNING] 
> 包含破坏性变更

## 背景
读路径有两类属主/管理员鉴权缺口：
① 节点审批人/候选人/巡检等只读方法无租户作用域，拿着资源 ID 即可跨租户读审批人员身份（IDOR）；
② 一批列表 API 对「空租户」fail-open（DAO 遇空租户跳过过滤→跨租户全量），与单读 fail-closed 口径不一致。

## 修复
- H/M2 节点审批人只读（GetTaskCandidates/GetNodeApprovalStatus/GetNodeApprovers/
  GetNodeApprovalStatusByProcessInstance）：加 actor + ensureTenantAccess。
- M6 巡检端点（GetStuckProcessInstances/GetExpiredDelayTasks）：裸 tenantID → actor + requireInspectionTenant。
- L4 GetProcessInstancesByTaskConditions：加 actor，强制 req.TenantID=actor.TenantID，撤销透传。
- M5 列表 API 空租户 fail-open：新增 requireNonEmptyTenantForRealUser，应用到实例/任务/历史/流程定义列表；
  并同步修正 GetTaskComments/GetTaskByDefKey/GetTaskVariables 的空租户 fail-open。

## 破坏性变更
上述方法新增 actor 参数（与既有 GetTask/GetTaskComments 显式 actor 约定一致），宿主调用方需透传操作人。
系统身份空租户仍放行（平台级巡检扫描，设计内行为）。

## 验证
gofmt / go vet / go test ./... 全绿；新增跨租户拒绝 + 空租户 fail-closed 单测。