### PR TITLE
fix(service): 实例变量写入补属主校验，防止横向越权

### DIFF
--- a/components/ai_agent_node.go
+++ b/components/ai_agent_node.go
@@ -829,7 +829,7 @@ func (n *AIAgentNode) persistOutputForReuse(ctx types.RuleContext, msg types.Rul
 		return
 	}
 	if err := n.RuntimeService.SetProcessInstanceVariable(
-		ctx.GetContext(), actorFromCtxOrMeta(ctx, msg), instanceID, n.aiOutputVarKey(), string(buf)); err != nil {
+		service.WithInternalCallingMode(ctx.GetContext()), actorFromCtxOrMeta(ctx, msg), instanceID, n.aiOutputVarKey(), string(buf)); err != nil {
 		logrus.WithError(err).Warnf("AIAgentNode %s: persist output for reuse failed", n.GetSelfId())
 	}
 }

--- a/service/operator_authz.go
+++ b/service/operator_authz.go
@@ -7,14 +7,15 @@ import (
 	"github.com/rulego/gflow-engine/model"
 )
 
-// requireInstanceOwnerAuthorized 校验流程实例级生命周期变更（终止/挂起/删除/激活/重启/
-// 强恢复/重驱动/救援）的属主/管理员权限。放行三类：实例发起人自己、管理员
-// （SuperAdmin）、系统身份；其余（含无操作人）一律拒绝（fail-closed）。
+// requireInstanceOwnerAuthorized 校验流程实例级变更（生命周期：终止/挂起/删除/激活/重启/
+// 强恢复/重驱动/救援；实例变量写入：SetProcessInstanceVariables 等）的属主/管理员权限。
+// 放行三类：实例发起人自己、管理员（SuperAdmin）、系统身份；其余（含无操作人）一律拒绝。
 //
 // 引擎内部级联（CallingModeInternal，如失败终止 handleProcessInstanceFailure、驳回
-// 级联终止 terminateInstance）携带的是"参与该实例的真实用户"而非发起人，属流程语义
-// 驱动的副作用，不套用属主规则——这些调用方已显式以 WithInternalCallingMode 标记 ctx，
-// 本方法对其跳过，与 ensureTenantAccess（租户仍照常校验）互不干扰。
+// 级联终止 terminateInstance、AI 节点输出缓存持久化）携带的是"参与该实例的真实用户"
+// 而非发起人，属流程语义驱动的副作用，不套用属主规则——这些调用方已显式以
+// WithInternalCallingMode 标记 ctx，本方法对其跳过，与 ensureTenantAccess（租户仍照常
+// 校验）互不干扰。
 func requireInstanceOwnerAuthorized(ctx context.Context, instance *model.WfInstance) error {
 	if GetCallingMode(ctx) == CallingModeInternal {
 		return nil

--- a/service/runtime_service_impl.go
+++ b/service/runtime_service_impl.go
@@ -822,6 +822,11 @@ func (s *RuntimeServiceImpl) SetProcessInstanceVariables(ctx context.Context, ac
 	if err := ensureTenantAccess(ctx, "process instance", instance.TenantID); err != nil {
 		return err
 	}
+	// 属主校验：实例变量写入与生命周期级变更同口径（发起人/管理员/系统），
+	// 防止同租户横向越权改写他人实例变量；引擎内部级联经 CallingModeInternal 跳过。
+	if err := requireInstanceOwnerAuthorized(ctx, instance); err != nil {
+		return err
+	}
 
 	return WithInstanceTx(ctx, s.instanceDAO.Query, processInstanceID, func(scope *InstanceScope) error {
 		tx := scope.Tx()
@@ -886,6 +891,10 @@ func (s *RuntimeServiceImpl) getProcessInstanceVariablesInTx(ctx context.Context
 		return nil, fmt.Errorf("failed to get process instance: %w", err)
 	}
 	if err := ensureTenantAccess(ctx, "process instance", instance.TenantID); err != nil {
+		return nil, err
+	}
+	// 属主校验（锁内重读）：与入口处同口径，防并发窗口内越权写变量。
+	if err := requireInstanceOwnerAuthorized(ctx, instance); err != nil {
 		return nil, err
 	}
 	return ParseVariablesJSON(instance.Variables)

--- a/service/runtime_service_impl_test.go
+++ b/service/runtime_service_impl_test.go
@@ -396,7 +396,7 @@ func TestSetProcessInstanceVariables_ConcurrentMerge(t *testing.T) {
 			// FOR UPDATE 排队等待），重试模拟排队语义
 			var err error
 			for attempt := 0; attempt < 8; attempt++ {
-				err = svc.SetProcessInstanceVariables(ctx, Actor{UserID: "sys", TenantID: "t1"}, "inst-vars", map[string]interface{}{key: i})
+				err = svc.SetProcessInstanceVariables(ctx, Actor{UserID: "starter", TenantID: "t1"}, "inst-vars", map[string]interface{}{key: i})
 				if err == nil {
 					return
 				}
@@ -414,6 +414,35 @@ func TestSetProcessInstanceVariables_ConcurrentMerge(t *testing.T) {
 	got, err := svc.GetProcessInstanceVariables(ctx, ActorFromCtx(ctx), "inst-vars")
 	require.NoError(t, err)
 	require.Len(t, got, n, "并发批量写入不应互相覆盖")
+}
+
+// 实例变量写入的属主校验：同租户非发起人被拒（横向越权防护），发起人/管理员放行。
+func TestSetProcessInstanceVariables_OwnerAuthorized(t *testing.T) {
+	q := rtImplTestDB(t)
+	instDAO := dao.NewInstanceDAOWithQuery(q)
+	svc := &RuntimeServiceImpl{instanceDAO: instDAO}
+	ctx := context.Background()
+
+	require.NoError(t, instDAO.Create(ctx, &model.WfInstance{
+		ID: "inst-owner", ProcessID: "proc-1", Name: "owner", Status: string(enums.InstanceStatusActive),
+		TenantID: "t1", CreatedBy: "starter", StartUserID: "starter", CreatedAt: time.Now(),
+	}))
+
+	// 同租户非发起人 → 拒绝
+	err := svc.SetProcessInstanceVariables(ctx, Actor{UserID: "eve", TenantID: "t1"}, "inst-owner", map[string]interface{}{"k": "v"})
+	require.ErrorIs(t, err, ErrPermissionDenied)
+
+	// 发起人 → 放行
+	require.NoError(t, svc.SetProcessInstanceVariables(ctx, Actor{UserID: "starter", TenantID: "t1"}, "inst-owner", map[string]interface{}{"k": "v"}))
+
+	// 管理员 → 放行（单变量版）
+	require.NoError(t, svc.SetProcessInstanceVariable(ctx, Actor{UserID: "admin", TenantID: "t1", SuperAdmin: true}, "inst-owner", "k2", "v2"))
+
+	// 单变量删除：同租户非发起人 → 拒绝
+	require.ErrorIs(t, svc.RemoveProcessInstanceVariable(ctx, Actor{UserID: "eve", TenantID: "t1"}, "inst-owner", "k"), ErrPermissionDenied)
+
+	// 发起人删除 → 放行
+	require.NoError(t, svc.RemoveProcessInstanceVariable(ctx, Actor{UserID: "starter", TenantID: "t1"}, "inst-owner", "k"))
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
🤖 人工智能辅助贡献  
使用的工具：Deepseek Harness / deepseek v4 pro
参与程度：全部变更代码。所有代码均已人工审核并通过验证。

## 背景
审计发现实例变量写路径（SetProcessInstanceVariables / SetProcessInstanceVariable /
RemoveProcessInstanceVariable）只做跨租户隔离，缺少属主/管理员校验：同租户任意用户
拿到实例 ID 即可改写或删除他人实例变量（横向越权）。

## 修复
- 复用 requireInstanceOwnerAuthorized（发起人/管理员/系统，CallingModeInternal 跳过），
  与生命周期级变更（终止/挂起/删除/重启等）同口径。
- 批量版在租户校验后追加属主校验；单变量版/删除版经 getProcessInstanceVariablesInTx
  在实例行锁内重读处再校验，防并发窗口越权。

## 引擎内部级联不误伤
AI 节点在流转中把同步输出缓存写回本实例，携带的是流程参与人而非发起人（流程语义副作用）。
persistOutputForReuse 调用点显式标记 WithInternalCallingMode，属主校验跳过、租户仍照常校验，
与 PR1 的 terminateInstance / handleProcessInstanceFailure 同套路。任务变量写路径已有
authorizeTaskOperator（assignee+租户 fail-closed），不在本次范围。

## 验证
gofmt / go vet / go test ./... 全绿；新增 OwnerAuthorized 单测，并发合并用例改用发起人身份。