### PR TITLE
fix(service): 历史归档删除补属主/办理人校验，防止横向越权

### DIFF
--- a/service/history_service_impl.go
+++ b/service/history_service_impl.go
@@ -231,6 +231,11 @@ func (s *HistoryServiceImpl) DeleteHistoricProcessInstance(ctx context.Context, 
 	if err := ensureTenantAccess(ctx, "historic process instance", record.TenantID); err != nil {
 		return err
 	}
+	// 属主校验：归档删除与在办实例生命周期同口径（发起人/管理员/系统），
+	// 防止同租户横向越权删除他人归档记录。
+	if err := requireInstanceOwnerAuthorized(ctx, record); err != nil {
+		return err
+	}
 
 	if err := s.hiInstanceDAO.Delete(ctx, processInstanceID); err != nil {
 		return fmt.Errorf("failed to delete historic process instance: %w", err)
@@ -255,6 +260,11 @@ func (s *HistoryServiceImpl) DeleteHistoricTaskInstance(ctx context.Context, act
 		return fmt.Errorf("%w: historic task instance", ErrNotFound)
 	}
 	if err := ensureTenantAccess(ctx, "historic task instance", record.TenantID); err != nil {
+		return err
+	}
+	// 办理人校验：归档任务删除与在办任务操作同口径（assignee/管理员/系统），
+	// 防止同租户横向越权删除他人历史任务记录。
+	if err := requireTaskOperatorAuthorized(ctx, record); err != nil {
 		return err
 	}
 

--- a/service/history_service_impl_test.go
+++ b/service/history_service_impl_test.go
@@ -5,7 +5,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/rulego/gflow-engine/dao"
 	"github.com/rulego/gflow-engine/model"
+	"github.com/stretchr/testify/require"
 )
 
 // ---------------------------------------------------------------------------
@@ -264,4 +266,57 @@ func TestHistoryService_DeleteHistoricTaskInstance_EmptyID(t *testing.T) {
 	if err == nil {
 		t.Error("expected error for empty ID")
 	}
+}
+
+// 历史实例删除的属主校验：同租户非发起人被拒，发起人/管理员放行（横向越权防护）。
+func TestHistoryService_DeleteHistoricProcessInstance_OwnerAuthorized(t *testing.T) {
+	q := secFixDB(t)
+	ctx := context.Background()
+	require.NoError(t, q.WfHiInstance.Create(&model.WfHiInstance{
+		ID: "hi-inst-1", ProcessID: "proc-1", Name: "h", Status: "completed",
+		StartUserID: "starter", TenantID: "t1", CreatedBy: "starter", CreatedAt: time.Now(),
+	}))
+	svc := &HistoryServiceImpl{hiInstanceDAO: dao.NewHiInstanceDAOWithQuery(q)}
+
+	// 同租户非发起人 → 拒绝
+	err := svc.DeleteHistoricProcessInstance(ctx, Actor{UserID: "eve", TenantID: "t1"}, "hi-inst-1")
+	require.ErrorIs(t, err, ErrPermissionDenied, "同租户非发起人删除他人归档实例应被拒绝")
+
+	// 空操作人 → 拒绝（fail-closed）
+	err = svc.DeleteHistoricProcessInstance(ctx, Actor{TenantID: "t1"}, "hi-inst-1")
+	require.ErrorIs(t, err, ErrAuthenticationRequired, "空操作人删除归档实例应被拒绝")
+
+	// 发起人 → 放行
+	require.NoError(t, svc.DeleteHistoricProcessInstance(ctx, Actor{UserID: "starter", TenantID: "t1"}, "hi-inst-1"))
+}
+
+// 历史任务删除的办理人校验：同租户非办理人被拒，办理人/管理员放行。
+func TestHistoryService_DeleteHistoricTaskInstance_OperatorAuthorized(t *testing.T) {
+	q := secFixDB(t)
+	ctx := context.Background()
+	require.NoError(t, q.WfHiTask.Create(&model.WfHiTask{
+		ID: "hi-task-1", ProcessID: "proc-1", TaskType: "user_task", Name: "审批",
+		Status: "completed", Assignee: secFixStrPtr("worker"), TenantID: "t1", CreatedBy: "system", CreatedAt: time.Now(),
+	}))
+	svc := &HistoryServiceImpl{hiTaskDAO: dao.NewHiTaskDAOWithQuery(q)}
+
+	// 同租户非办理人 → 拒绝
+	err := svc.DeleteHistoricTaskInstance(ctx, Actor{UserID: "eve", TenantID: "t1"}, "hi-task-1")
+	require.ErrorIs(t, err, ErrPermissionDenied, "同租户非办理人删除他人归档任务应被拒绝")
+
+	// 办理人 → 放行
+	require.NoError(t, svc.DeleteHistoricTaskInstance(ctx, Actor{UserID: "worker", TenantID: "t1"}, "hi-task-1"))
+}
+
+// 历史任务删除的管理员放行（SuperAdmin 同租户）。
+func TestHistoryService_DeleteHistoricTaskInstance_AdminAuthorized(t *testing.T) {
+	q := secFixDB(t)
+	ctx := context.Background()
+	require.NoError(t, q.WfHiTask.Create(&model.WfHiTask{
+		ID: "hi-task-2", ProcessID: "proc-1", TaskType: "user_task", Name: "审批",
+		Status: "completed", Assignee: secFixStrPtr("worker"), TenantID: "t1", CreatedBy: "system", CreatedAt: time.Now(),
+	}))
+	svc := &HistoryServiceImpl{hiTaskDAO: dao.NewHiTaskDAOWithQuery(q)}
+
+	require.NoError(t, svc.DeleteHistoricTaskInstance(ctx, Actor{UserID: "admin", TenantID: "t1", SuperAdmin: true}, "hi-task-2"))
 }


### PR DESCRIPTION
🤖 人工智能辅助贡献  
使用的工具：Deepseek Harness / deepseek v4 pro
参与程度：全部变更代码。所有代码均已人工审核并通过验证。

## 背景
DeleteHistoricProcessInstance / DeleteHistoricTaskInstance 原来只做跨租户隔离
（ensureTenantAccess），缺属主/办理人校验：同租户任意用户凭 ID 即可删除他人
归档实例/任务记录（横向越权）。

## 修复
复用 requireInstanceOwnerAuthorized / requireTaskOperatorAuthorized：
- 归档实例删除 → 发起人/管理员/系统
- 归档任务删除 → assignee/管理员/系统

说明：HiInstanceDAO.Get / HiTaskDAO.Get 扫描返回在办模型（WfInstance/WfTask），
故直接复用同名口径 helper，无历史模型专属副本。

## 验证
gofmt / go vet / go test ./... 全绿；新增 owner/operator/admin 三组 DB 用例。