### PR TITLE
fix(service): 流程定义变更类操作补管理员门槛

### DIFF
--- a/service/process_service_impl.go
+++ b/service/process_service_impl.go
@@ -60,6 +60,10 @@ func (s *ProcessServiceImpl) Update(ctx context.Context, actor Actor, process *m
 	if process.ID == "" {
 		return fmt.Errorf("process ID cannot be empty")
 	}
+	// 管理员门槛：修改流程定义（DSL/版本递增）影响后续发起，仅管理员或系统身份可操作。
+	if err := requireAdminIdentity(&actor); err != nil {
+		return err
+	}
 
 	// 1. 获取现有流程定义以检查权限
 	existingProcess, err := s.processDAO.Get(ctx, process.ID)
@@ -353,6 +357,10 @@ func (s *ProcessServiceImpl) Delete(ctx context.Context, actor Actor, processID 
 	if processID == "" {
 		return fmt.Errorf("process definition ID cannot be empty")
 	}
+	// 管理员门槛：删除流程定义属租户级管理操作，仅管理员或系统身份可操作。
+	if err := requireAdminIdentity(&actor); err != nil {
+		return err
+	}
 
 	// 检查是否有正在运行的流程实例
 	// 如果有正在运行的实例，应该禁止删除或者提供强制删除选项
@@ -386,6 +394,10 @@ func (s *ProcessServiceImpl) Retire(ctx context.Context, actor Actor, processID 
 // Activate 激活流程定义，并创建新的版本
 func (s *ProcessServiceImpl) Activate(ctx context.Context, actor Actor, processID string) (*model.WfProcess, error) {
 	ctx = bindActor(ctx, actor)
+	// 管理员门槛：激活流程定义（生成新 active 版本）仅管理员或系统身份可操作。
+	if err := requireAdminIdentity(&actor); err != nil {
+		return nil, err
+	}
 	process, err := s.Get(ctx, processID)
 	if err != nil {
 		return nil, err
@@ -398,6 +410,10 @@ func (s *ProcessServiceImpl) UpdateStatus(ctx context.Context, actor Actor, proc
 	ctx = bindActor(ctx, actor)
 	if processID == "" {
 		return fmt.Errorf("process ID cannot be empty")
+	}
+	// 管理员门槛：变更流程定义状态仅管理员或系统身份可操作。
+	if err := requireAdminIdentity(&actor); err != nil {
+		return err
 	}
 
 	process, err := s.processDAO.Get(ctx, processID)
@@ -421,6 +437,10 @@ func (s *ProcessServiceImpl) UpdateStatusByKey(ctx context.Context, actor Actor,
 	tenantID := actor.TenantID
 	if processKey == "" {
 		return fmt.Errorf("process key cannot be empty")
+	}
+	// 管理员门槛：按 key 变更流程定义状态仅管理员或系统身份可操作。
+	if err := requireAdminIdentity(&actor); err != nil {
+		return err
 	}
 
 	process, err := s.processDAO.GetLatestByKey(ctx, tenantID, processKey)

--- a/service/process_service_impl_test.go
+++ b/service/process_service_impl_test.go
@@ -156,13 +156,13 @@ func TestProcessServiceImpl_Update_EmptyID(t *testing.T) {
 func TestProcessServiceImpl_Update_NilDAO_Panics(t *testing.T) {
 	s := &ProcessServiceImpl{}
 	expectPanic(t, "Update", func() {
-		s.Update(context.Background(), Actor{UserID: "tester", TenantID: "t1"}, &model.WfProcess{ID: "proc-1", Name: "Test"})
+		s.Update(context.Background(), Actor{UserID: "tester", TenantID: "t1", SuperAdmin: true}, &model.WfProcess{ID: "proc-1", Name: "Test"})
 	})
 }
 
 func TestProcessServiceImpl_Activate_EmptyID(t *testing.T) {
 	s := newProcessServiceImplForTest()
-	_, err := s.Activate(context.Background(), Actor{UserID: "tester", TenantID: "tenant1"}, "")
+	_, err := s.Activate(context.Background(), Actor{UserID: "tester", TenantID: "tenant1", SuperAdmin: true}, "")
 	if err == nil {
 		t.Error("expected error for empty processID")
 	}
@@ -185,29 +185,59 @@ func TestProcessServiceImpl_List_NilDAO_Panics(t *testing.T) {
 func TestProcessServiceImpl_Delete_NilInstanceDAO_Panics(t *testing.T) {
 	s := &ProcessServiceImpl{}
 	expectPanic(t, "Delete", func() {
-		s.Delete(context.Background(), Actor{UserID: "tester", TenantID: "t1"}, "proc-1")
+		s.Delete(context.Background(), Actor{UserID: "tester", TenantID: "t1", SuperAdmin: true}, "proc-1")
 	})
 }
 
 func TestProcessServiceImpl_UpdateStatus_NilDAO_Panics(t *testing.T) {
 	s := &ProcessServiceImpl{}
 	expectPanic(t, "UpdateStatus", func() {
-		s.UpdateStatus(context.Background(), Actor{UserID: "tester", TenantID: "t1"}, "proc-1", "active")
+		s.UpdateStatus(context.Background(), Actor{UserID: "tester", TenantID: "t1", SuperAdmin: true}, "proc-1", "active")
 	})
 }
 
 func TestProcessServiceImpl_UpdateStatusByKey_NilDAO_Panics(t *testing.T) {
 	s := &ProcessServiceImpl{}
 	expectPanic(t, "UpdateStatusByKey", func() {
-		s.UpdateStatusByKey(context.Background(), Actor{UserID: "tester", TenantID: "t1"}, "key1", "active")
+		s.UpdateStatusByKey(context.Background(), Actor{UserID: "tester", TenantID: "t1", SuperAdmin: true}, "key1", "active")
 	})
 }
 
 func TestProcessServiceImpl_Retire_NilDAO_Panics(t *testing.T) {
 	s := &ProcessServiceImpl{}
 	expectPanic(t, "Retire", func() {
-		s.Retire(context.Background(), Actor{UserID: "tester", TenantID: "t1"}, "proc-1")
+		s.Retire(context.Background(), Actor{UserID: "tester", TenantID: "t1", SuperAdmin: true}, "proc-1")
 	})
+}
+
+// 流程定义变更类操作（改/删/停用/激活/状态变更）须管理员或系统身份，
+// 同租户普通用户一律拒绝（fail-closed）。用 nil DAO 验证：非管理员在触达 DAO 前即被拒，
+// 不会走进 nil 指针路径。
+func TestProcessServiceImpl_DefinitionMutations_RequireAdmin(t *testing.T) {
+	s := &ProcessServiceImpl{}
+	nonAdmin := Actor{UserID: "eve", TenantID: "t1"}
+	cases := []struct {
+		name string
+		fn   func() error
+	}{
+		{"Update", func() error { return s.Update(context.Background(), nonAdmin, &model.WfProcess{ID: "p", Name: "n"}) }},
+		{"Delete", func() error { return s.Delete(context.Background(), nonAdmin, "proc-1") }},
+		{"Retire", func() error { return s.Retire(context.Background(), nonAdmin, "proc-1") }},
+		{"Activate", func() error { _, err := s.Activate(context.Background(), nonAdmin, "proc-1"); return err }},
+		{"UpdateStatus", func() error { return s.UpdateStatus(context.Background(), nonAdmin, "proc-1", "active") }},
+		{"UpdateStatusByKey", func() error { return s.UpdateStatusByKey(context.Background(), nonAdmin, "key1", "active") }},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.fn()
+			if err == nil {
+				t.Fatalf("%s: expected error for non-admin operator", tc.name)
+			}
+			if !errors.Is(err, ErrPermissionDenied) {
+				t.Fatalf("%s: expected ErrPermissionDenied, got %v", tc.name, err)
+			}
+		})
+	}
 }
 
 func TestNewProcessService_NilEngine(t *testing.T) {


### PR DESCRIPTION
🤖 人工智能辅助贡献  
使用的工具：Deepseek Harness / deepseek v4 pro
参与程度：全部变更代码。所有代码均已人工审核并通过验证。

## 背景
流程定义是租户级共享资源。Update / Delete / Retire / Activate / UpdateStatus /
UpdateStatusByKey 原来只做跨租户隔离，不做身份等级校验：同租户任意普通用户即可
修改、删除、停用、激活流程定义，横向越权改动租户的共享流程模板，直接影响后续
所有实例的发起行为。

## 修复
在上述变更类入口统一补 requireAdminIdentity（仅 SuperAdmin 或系统身份放行，
fail-closed）：
- Update：修改 DSL / 版本递增
- Delete：删除流程定义
- Activate：激活生成新 active 版本
- UpdateStatus / UpdateStatusByKey：变更流程定义状态
- Retire：经 UpdateStatus 复用同一门槛

跨租户隔离（ensureTenantAccess / DAO 按租户过滤）保持不变，与管理员门槛叠加。
校验顺序为先空参校验、再管理员门槛、再租户/DAO，保证参数错误仍返回参数错误。

## 验证
gofmt / go vet / go test ./... 全绿。
新增 DefinitionMutations_RequireAdmin 用例：六条变更路径以非管理员身份调用均返回
ErrPermissionDenied（用 nil DAO 验证在触达 DAO 前即被拒）。
受影响的 nil-DAO / 空 ID 单测改为管理员身份，保持原有 panic/校验断言语义。