### PR TITLE
fix(service): 恢复（重驱动）实例补属主校验，堵住横向越权

### DIFF
--- a/service/runtime_service_impl.go
+++ b/service/runtime_service_impl.go
@@ -1471,6 +1471,11 @@ func (s *RuntimeServiceImpl) RestoreProcessInstance(ctx context.Context, actor A
 	if err := ensureTenantAccess(ctx, "process instance", instance.TenantID); err != nil {
 		return err
 	}
+	// 属主校验：恢复（重驱动全部在办/待触发任务）会重新执行节点副作用，
+	// 与实例生命周期级变更同口径（发起人/管理员/系统），防止同租户横向越权重驱动他人实例。
+	if err := requireInstanceOwnerAuthorized(ctx, instance); err != nil {
+		return err
+	}
 
 	// 恢复的读-判-驱窗口须与对端副本的驱动互斥，避免基于过期任务快照重复 restore
 	if unlock := s.acquireDistExecGate(ctx, processInstanceID); unlock != nil {

--- a/service/runtime_service_impl_test.go
+++ b/service/runtime_service_impl_test.go
@@ -278,6 +278,23 @@ func TestRuntimeServiceImpl_RestoreProcessInstance_NilDAO_Panics(t *testing.T) {
 	})
 }
 
+// 恢复（重驱动）实例须属主/管理员：同租户非发起人被拒（横向越权防护）。
+func TestRuntimeServiceImpl_RestoreProcessInstance_OwnerAuthorized(t *testing.T) {
+	q := rtImplTestDB(t)
+	instDAO := dao.NewInstanceDAOWithQuery(q)
+	svc := &RuntimeServiceImpl{instanceDAO: instDAO}
+	ctx := context.Background()
+
+	require.NoError(t, instDAO.Create(ctx, &model.WfInstance{
+		ID: "inst-restore", ProcessID: "proc-1", Name: "restore", Status: string(enums.InstanceStatusActive),
+		TenantID: "t1", CreatedBy: "starter", StartUserID: "starter", CreatedAt: time.Now(),
+	}))
+
+	// 同租户非发起人 → 拒绝（属主校验在租户校验之后、重驱动之前触发）
+	err := svc.RestoreProcessInstance(ctx, Actor{UserID: "eve", TenantID: "t1"}, "inst-restore")
+	require.ErrorIs(t, err, ErrPermissionDenied)
+}
+
 // ---------------------------------------------------------------------------
 // RestoreAllProcessInstances
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
🤖 人工智能辅助贡献  
使用的工具：Deepseek Harness / deepseek v4 pro
参与程度：全部变更代码。所有代码均已人工审核并通过验证。

## 背景
RestoreProcessInstance 原来只做跨租户隔离，不做属主校验：同租户任意用户凭实例 ID
即可重驱动他人实例的全部在办/待触发任务。恢复会重新执行节点副作用（重复审批、
重复调用外部服务、重复派发事件），因此属越权写操作。

## 修复
在租户校验之后、取分布执行门闩重驱动之前补 requireInstanceOwnerAuthorized：
- 放行：实例发起人、管理员（SuperAdmin）、系统身份
- 拒绝：其余同租户普通用户、无操作人（fail-closed）

校验顺序：空 ID → 实例存在性 → 跨租户 → 属主 → 分布门闩 → 重驱动。
系统/管理员放行路径保持既有语义（RestoreAllProcessInstances 全租户巡检、
宿主启动恢复、单实例系统恢复不受影响）。

## 验证
gofmt / go vet / go test ./... 全绿。
新增 RestoreProcessInstance_OwnerAuthorized 用例：同租户非发起人恢复他人实例
返回 ErrPermissionDenied。