### PR TITLE
fix(service): 任务评论文本补办理人校验，防止横向越权

### DIFF
--- a/service/task_service_comment.go
+++ b/service/task_service_comment.go
@@ -37,6 +37,11 @@ func (s *TaskServiceImpl) AddTaskComment(ctx context.Context, actor Actor, taskI
 	if u != nil && task.TenantID != u.TenantID {
 		return "", fmt.Errorf("%w: task", ErrNotFound)
 	}
+	// 办理人校验：评论文本同样须任务办理人（assignee）或管理员/系统身份，
+	// 防止同租户任意用户给他人任务灌入审批意见（横向越权）。与任务属性变更同口径。
+	if err := requireTaskOperatorAuthorized(ctx, task); err != nil {
+		return "", err
+	}
 
 	userName := ""
 	if u != nil && u.UserID == userID {

--- a/service/task_service_comment_test.go
+++ b/service/task_service_comment_test.go
@@ -71,7 +71,7 @@ func TestTaskComments_Roundtrip(t *testing.T) {
 	require.NoError(t, svc.taskDAO.Create(ctx, &model.WfTask{
 		ID: "task-c1", Status: string(enums.TaskStatusActive), TenantID: "t1",
 		ProcessInstanceID: secFixStrPtr("inst-c1"), Name: "审批", TaskType: "user_task",
-		CreatedAt: now, CreatedBy: "sys",
+		Assignee: secFixStrPtr("userA"), CreatedAt: now, CreatedBy: "sys",
 	}))
 	id1, err := svc.AddTaskComment(ctx, Actor{UserID: "userA", UserName: "张三", TenantID: "t1"}, "task-c1", "同意")
 	require.NoError(t, err)
@@ -81,7 +81,7 @@ func TestTaskComments_Roundtrip(t *testing.T) {
 	require.NoError(t, svc.hiTaskDAO.Create(ctx, &model.WfHiTask{
 		ID: "task-c2", Status: string(enums.TaskStatusCompleted), TenantID: "t1",
 		ProcessInstanceID: secFixStrPtr("inst-c2"), Name: "审批", TaskType: "user_task",
-		CreatedAt: now, CreatedBy: "sys",
+		Assignee: secFixStrPtr("userA"), CreatedAt: now, CreatedBy: "sys",
 	}))
 	_, err = svc.AddTaskComment(ctx, Actor{UserID: "userA", UserName: "张三", TenantID: "t1"}, "task-c2", "补充意见")
 	require.NoError(t, err, "归档任务应可评论")
@@ -113,4 +113,30 @@ func TestTaskComments_Roundtrip(t *testing.T) {
 	// 不存在的任务
 	_, err = svc.GetTaskComments(ctx, ActorFromCtx(ctx), "task-ghost")
 	require.ErrorIs(t, err, ErrNotFound)
+}
+
+// 评论文本写路径须办理人/管理员/系统身份：同租户非办理人被拒（横向越权防护）。
+func TestTaskComments_RequireAssigneeOrAdmin(t *testing.T) {
+	q := commentTestDB(t)
+	svc := newCommentSvc(q)
+	ctx := context.Background()
+	now := time.Now()
+
+	require.NoError(t, svc.taskDAO.Create(ctx, &model.WfTask{
+		ID: "task-p1", Status: string(enums.TaskStatusActive), TenantID: "t1",
+		ProcessInstanceID: secFixStrPtr("inst-p1"), Name: "审批", TaskType: "user_task",
+		Assignee: secFixStrPtr("worker"), CreatedAt: now, CreatedBy: "sys",
+	}))
+
+	// 同租户非办理人 → 拒绝
+	_, err := svc.AddTaskComment(ctx, Actor{UserID: "eve", TenantID: "t1"}, "task-p1", "越权评论")
+	require.ErrorIs(t, err, ErrPermissionDenied, "同租户非办理人评论他人任务应被拒绝")
+
+	// 办理人 → 放行
+	_, err = svc.AddTaskComment(ctx, Actor{UserID: "worker", TenantID: "t1"}, "task-p1", "正常意见")
+	require.NoError(t, err)
+
+	// 管理员 → 放行
+	_, err = svc.AddTaskComment(ctx, Actor{UserID: "admin", TenantID: "t1", SuperAdmin: true}, "task-p1", "管理意见")
+	require.NoError(t, err)
 }


### PR DESCRIPTION
🤖 人工智能辅助贡献  
使用的工具：Deepseek Harness / deepseek v4 pro
参与程度：全部变更代码。所有代码均已人工审核并通过验证。

## 背景
AddTaskComment 原来只做跨租户隔离，不做办理人校验：同租户任意用户即可给他人任务
灌入审批意见，属横向越权写操作（伪造审批语义、制造审计噪音）。

## 修复
在租户校验之后、落库之前补 requireTaskOperatorAuthorized校验：
- 放行：任务办理人（assignee）、管理员（SuperAdmin）、系统身份
- 拒绝：同租户非办理人（ErrPermissionDenied）；未指派任务仅管理员/系统可评论
  （fail-closed）
- 跨租户仍按不存在（ErrNotFound）处理

校验顺序：空 ID → 空内容 → 空身份 → 定位任务 → 跨租户 → 办理人 → 落库。
与任务变量写入、任务属性变更的鉴权口径保持一致。

## 验证
gofmt / go vet / go test ./... 全绿。
新增 RequireAssigneeOrAdmin 用例：同租户非办理人被拒、办理人/管理员放行；
Roundtrip 用例任务改为指派给 userA 以保持原语义。