### PR TITLE
fix(service): serviceTask 函数名校验器读写加锁，消除数据竞态

### DIFF
--- a/service/condition_validate.go
+++ b/service/condition_validate.go
@@ -3,6 +3,7 @@ package service
 import (
 	"fmt"
 	"strings"
+	"sync"
 
 	"github.com/rulego/gflow-engine/types/constants"
 	"github.com/rulego/rulego/api/types"
@@ -33,11 +34,25 @@ type ConditionIssue struct {
 // serviceFunctionChecker serviceTask 函数名存在性校验器，由组件层
 // （components.Services 所在包）经 SetServiceFunctionChecker 注入，避免
 // service→components 循环依赖。nil 时跳过函数名校验（宿主未完成装配的场景）。
-var serviceFunctionChecker func(name string) bool
+// 读侧在 Deploy/Update 请求处理路径（ValidateChainExpressions）并发执行，
+// 写侧在宿主装配（components.Register）时注入，故须加锁避免并发读写竞态。
+var (
+	serviceFunctionChecker   func(name string) bool
+	serviceFunctionCheckerMu sync.RWMutex
+)
 
-// SetServiceFunctionChecker 注入 serviceTask 函数名校验器；传 nil 恢复跳过。
+// SetServiceFunctionChecker 注入 serviceTask 函数名校验器；传 nil 恢复跳过。并发安全。
 func SetServiceFunctionChecker(fn func(name string) bool) {
+	serviceFunctionCheckerMu.Lock()
+	defer serviceFunctionCheckerMu.Unlock()
 	serviceFunctionChecker = fn
+}
+
+// serviceFunctionCheckerForRead 并发安全地读取当前校验器（读锁）。
+func serviceFunctionCheckerForRead() func(name string) bool {
+	serviceFunctionCheckerMu.RLock()
+	defer serviceFunctionCheckerMu.RUnlock()
+	return serviceFunctionChecker
 }
 
 // ValidateChainExpressions 校验链内所有分支条件表达式可编译、serviceTask
@@ -107,7 +122,7 @@ func validateServiceTaskFunction(node *types.RuleNode, cfg map[string]interface{
 		issue.Error = "functionName is empty"
 		return []ConditionIssue{issue}
 	}
-	if serviceFunctionChecker != nil && !serviceFunctionChecker(name) {
+	if checker := serviceFunctionCheckerForRead(); checker != nil && !checker(name) {
 		issue.Error = "function is not registered"
 		return []ConditionIssue{issue}
 	}

--- a/service/condition_validate_test.go
+++ b/service/condition_validate_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/rulego/gflow-engine/model"
@@ -161,4 +162,37 @@ func TestValidateExpressions(t *testing.T) {
 	if errs := ValidateExpressions([]string{"true"}); len(errs) != 0 {
 		t.Errorf("valid expression should pass: %v", errs)
 	}
+}
+
+// TestServiceFunctionChecker_ConcurrentAccess 验证校验器读写并发安全：
+// 宿主装配（SetServiceFunctionChecker）与 Deploy/Update 请求路径的读取
+// validateServiceTaskFunction 可能并发，须经 RWMutex 保护；在 go test -race
+// 下可捕获漏同步，普通运行下仅演练读写路径。
+func TestServiceFunctionChecker_ConcurrentAccess(t *testing.T) {
+	defer SetServiceFunctionChecker(nil)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 200; j++ {
+				SetServiceFunctionChecker(func(name string) bool { return name == "serialNo" })
+				if fn := serviceFunctionCheckerForRead(); fn == nil {
+					t.Errorf("checker should be set during write phase")
+					return
+				}
+			}
+		}()
+	}
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 200; j++ {
+				_ = serviceFunctionCheckerForRead()
+			}
+		}()
+	}
+	wg.Wait()
 }


### PR DESCRIPTION
🤖 人工智能辅助贡献  
使用的工具：Deepseek Harness / deepseek v4 pro
参与程度：全部变更代码。所有代码均已人工审核并通过验证。

## 背景
serviceFunctionChecker 是进程级可注册运行时状态：写侧在宿主装配（components.Register → SetServiceFunctionChecker）注入，读侧在 Deploy/Update 请求路径（ValidateChainExpressions → validateServiceTaskFunction）并发执行。原来直接读写包级函数变量、无同步，是 service 包中唯一未加锁的可注册运行时单例，运行中重装配组件或测试并行 Set/读时会触发数据竞态（go test -race 报错）。

## 修复
补 sync.RWMutex：
- SetServiceFunctionChecker 取写锁写入
- 读侧新增 serviceFunctionCheckerForRead 取读锁读取
与同包 DefaultIDGenerator（defaultIDGenMu）、DialectRegistry（mutex）等可注册运行时单例的并发安全口径保持一致。

## 验证
gofmt / go vet / go test ./... 全绿；
新增 ConcurrentAccess 用例（并发 Set/读），go test -race ./service/
-run TestServiceFunctionChecker_ConcurrentAccess 通过。