### PR TITLE
fix: 收紧 startProcess/子流程/自选抄送的信任边界

### DIFF
--- a/components/cc_task_node.go
+++ b/components/cc_task_node.go
@@ -46,6 +46,9 @@ type CCTaskNode struct {
 	Config         CCTaskNodeConfiguration
 	TaskService    service.TaskServiceInternal
 	CurrentNodeDef types.RuleNode
+	// IdentityService 身份服务：自选抄送人（selfSelect 业务变量）校验用户属于实例租户
+	// （TenantMembershipChecker）。由 Register 注入；未实现该接口的宿主跳过校验。
+	IdentityService service.IdentityService
 
 	// OnCCTaskCreated 由 Builder.SetCCTaskCreatedListener 经
 	// Register 注入。每条 CC 任务创建成功后调用一次。
@@ -64,6 +67,7 @@ func (x *CCTaskNode) New() types.Node {
 		TaskService: x.TaskService,
 		// 监听器从注册原型拷贝到每条链的执行实例，漏掉会导致 CC 事件被静默丢弃
 		OnCCTaskCreated: x.OnCCTaskCreated,
+		IdentityService: x.IdentityService,
 	}
 }
 
@@ -141,6 +145,14 @@ func (x *CCTaskNode) OnMsg(ctx types.RuleContext, msg types.RuleMsg) {
 		failedCount := 0
 		firstErr := error(nil)
 		for _, userId := range finalUserIds {
+			// 抄送人必须属于实例租户：拦截业务变量/静态名单里夹带的跨租户 userId（越租户抄送）。
+			if err := service.EnsureUserInTenant(ctx.GetContext(), x.IdentityService, tenantID, userId); err != nil {
+				failedCount++
+				if firstErr == nil {
+					firstErr = fmt.Errorf("cc user %q not in tenant %q: %w", userId, tenantID, err)
+				}
+				continue
+			}
 			task := &model.WfTask{
 				ProcessInstanceID: &processInstanceID,
 				ProcessID:         processID,

--- a/components/cc_task_node_test.go
+++ b/components/cc_task_node_test.go
@@ -128,6 +128,9 @@ func (f *fakeCCTaskService) snapshot() []*model.WfTask {
 var (
 	ccTestTaskSvc  = &fakeCCTaskService{}
 	ccRegisterOnce sync.Once
+	// ccTestIdentity 注册进 ccTask 原型的租户身份源：默认全部"在租户内"，
+	// 跨租户过滤用例用 deny + reset。
+	ccTestIdentity = &fakeTenantChecker{}
 	// 链 ID 必须每用例唯一：rulego.New 对已存在的 ID 直接复用旧链，
 	// 用例会跑在别的节点配置上（时间戳在 Windows 粗粒度时钟下会撞车）
 	ccChainSeq atomic.Int64
@@ -137,7 +140,10 @@ var (
 func registerCCTaskForTest(t *testing.T) {
 	t.Helper()
 	ccRegisterOnce.Do(func() {
-		if err := rulego.Registry.Register(&CCTaskNode{TaskService: ccTestTaskSvc}); err != nil &&
+		if err := rulego.Registry.Register(&CCTaskNode{
+			TaskService:     ccTestTaskSvc,
+			IdentityService: ccTestIdentity,
+		}); err != nil &&
 			!strings.Contains(err.Error(), "already exists") {
 			t.Fatalf("register ccTask node: %v", err)
 		}
@@ -214,4 +220,15 @@ func TestCCTaskNode_OnMsg_StaticListWithoutSelfSelect(t *testing.T) {
 		`{"ccUserIds":["u-a","u-b"],"selfSelect":false}`,
 		`{}`)
 	require.ElementsMatch(t, []string{"u-a", "u-b"}, assignees)
+}
+
+// 自选/静态名单夹带跨租户 userId：被租户校验过滤，不创建越租户抄送任务。
+func TestCCTaskNode_OnMsg_SelfSelectFiltersCrossTenant(t *testing.T) {
+	ccTestIdentity.deny("u-self-2")
+	defer ccTestIdentity.reset()
+
+	assignees := runCCEngine(t,
+		`{"ccUserIds":["u-static"],"selfSelect":true}`,
+		`{"ccUserIds":["u-self-1","u-self-2"]}`)
+	require.Equal(t, []string{"u-self-1"}, assignees)
 }

--- a/components/register.go
+++ b/components/register.go
@@ -110,6 +110,7 @@ func Register(deps ComponentDeps) error {
 	// 注册抄送任务节点
 	ccTaskNode := &CCTaskNode{
 		TaskService:     taskService,
+		IdentityService: identityService,
 		OnCCTaskCreated: ccTaskCreatedListener,
 	}
 	if err := registerNode(ccTaskNode); err != nil {
@@ -152,7 +153,7 @@ func Register(deps ComponentDeps) error {
 	// 注册发起审批节点（startProcess）。规则链内以指定发起人启动 BPM 流程实例，
 	// 定时链经此实现"定时自动发起审批"。BPM 设计器面板不含此节点（硬编码清单），
 	// 仅经全局 Registry 出现在规则链编辑器组件面板。
-	if err := registerNode(&StartProcessNode{RuntimeService: runtimeService}); err != nil {
+	if err := registerNode(&StartProcessNode{RuntimeService: runtimeService, IdentityService: identityService}); err != nil {
 		return err
 	}
 

--- a/components/start_process_node.go
+++ b/components/start_process_node.go
@@ -45,6 +45,9 @@ type StartProcessNodeConfig struct {
 type StartProcessNode struct {
 	Config         StartProcessNodeConfig
 	RuntimeService service.RuntimeServiceInternal
+	// IdentityService 身份服务：校验发起人 initiator 属于目标租户（TenantMembershipChecker）。
+	// 由 Register 注入；未实现 TenantMembershipChecker 的宿主（含测试）跳过该成员校验。
+	IdentityService service.IdentityService
 
 	processKeyTmpl  el.Template
 	initiatorTmpl   el.Template
@@ -60,7 +63,8 @@ func (x *StartProcessNode) Category() string { return "bpm" }
 
 func (x *StartProcessNode) New() types.Node {
 	return &StartProcessNode{
-		RuntimeService: x.RuntimeService, // 从注册原型传播到 New 出的实例
+		RuntimeService:  x.RuntimeService,  // 从注册原型传播到 New 出的实例
+		IdentityService: x.IdentityService, // 同上
 	}
 }
 
@@ -139,7 +143,24 @@ func (x *StartProcessNode) OnMsg(ctx types.RuleContext, msg types.RuleMsg) {
 	}
 	evn := base.NodeUtils.GetEvnAndMetadata(ctx, msg)
 
+	// 租户解析：真实用户上下文以 ctx 内绑定的操作人租户为信任根（消息 metadata 可被调用方
+	// 任意伪造，不能作为越租户发起的依据）；仅系统/无操作人上下文（定时链、编辑器手动测试）
+	// 才退回 metadata.tenant_id 静态配置。
 	tenantID := metaValue(msg, constants.KeyTenantID)
+	if u := service.GetUserFromCtx(ctx.GetContext()); u != nil && !service.IsSystemActor(u) {
+		if u.TenantID == "" {
+			ctx.TellFailure(msg, fmt.Errorf(
+				"startProcess requires actor tenant; current actor %q has no tenant", u.UserID))
+			return
+		}
+		if tenantID != "" && tenantID != u.TenantID {
+			ctx.TellFailure(msg, fmt.Errorf(
+				"startProcess metadata.%s=%q mismatches actor tenant %q: %w",
+				constants.KeyTenantID, tenantID, u.TenantID, service.ErrPermissionDenied))
+			return
+		}
+		tenantID = u.TenantID
+	}
 	if tenantID == "" {
 		ctx.TellFailure(msg, fmt.Errorf(
 			"startProcess requires metadata.%s (scheduled chains carry it automatically; add it to debug metadata for manual testing)", constants.KeyTenantID))
@@ -153,6 +174,12 @@ func (x *StartProcessNode) OnMsg(ctx types.RuleContext, msg types.RuleMsg) {
 	initiator := x.initiatorTmpl.ExecuteAsString(evn)
 	if initiator == "" {
 		ctx.TellFailure(msg, fmt.Errorf("startProcess initiator resolves empty"))
+		return
+	}
+	// 发起人必须属于目标租户：阻断"以任意用户身份/任意租户"发起（身份伪造 + 越租户）。
+	if err := service.EnsureUserInTenant(ctx.GetContext(), x.IdentityService, tenantID, initiator); err != nil {
+		ctx.TellFailure(msg, fmt.Errorf(
+			"startProcess initiator %q not in tenant %q: %w", initiator, tenantID, err))
 		return
 	}
 	var businessKey string

--- a/components/start_process_node_test.go
+++ b/components/start_process_node_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/rulego/gflow-engine/service"
 	"github.com/rulego/gflow-engine/types/constants"
@@ -57,6 +58,10 @@ func (f *fakeStartProcessRuntime) calls() []map[string]interface{} {
 // 共享 fake：registry 原型只注册一次并绑定首个实例，各用例经 reset 配置期望值。
 var sharedStartProcessFake = &fakeStartProcessRuntime{}
 
+// spTestIdentity 注册进 startProcess 原型的租户身份源；默认全部用户"在租户内"，
+// 需要模拟跨租户/非成员时用 deny 标记并在用例结束 reset。
+var spTestIdentity = &fakeTenantChecker{}
+
 func resetStartProcessFake(instanceID string, err error) *fakeStartProcessRuntime {
 	sharedStartProcessFake.mu.Lock()
 	defer sharedStartProcessFake.mu.Unlock()
@@ -70,7 +75,10 @@ func resetStartProcessFake(instanceID string, err error) *fakeStartProcessRuntim
 func registerStartProcessForTest(t *testing.T) *fakeStartProcessRuntime {
 	t.Helper()
 	startProcessRegisterOnce.Do(func() {
-		if err := rulego.Registry.Register(&StartProcessNode{RuntimeService: sharedStartProcessFake}); err != nil {
+		if err := rulego.Registry.Register(&StartProcessNode{
+			RuntimeService:  sharedStartProcessFake,
+			IdentityService: spTestIdentity,
+		}); err != nil {
 			if !strings.Contains(err.Error(), "already exists") {
 				require.NoError(t, err)
 			}
@@ -237,4 +245,79 @@ func TestStartProcessNode_RuntimeError(t *testing.T) {
 	assert.Equal(t, types.Failure, rel)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "ghost")
+}
+
+// runStartProcessChainWithCtx 与 runChain 一致，但额外注入携带操作人的 Go context
+// （模拟 bindActor 写入 ctx 的下游链），用于验证租户信任根取自 ctx 而非 metadata。
+func runStartProcessChainWithCtx(t *testing.T, engine types.RuleEngine, msg types.RuleMsg, gctx context.Context) (types.RuleMsg, string, error) {
+	t.Helper()
+	done := make(chan struct{})
+	var endMsg types.RuleMsg
+	var rel string
+	var runErr error
+	engine.OnMsg(msg, types.WithContext(gctx), types.WithOnEnd(func(_ types.RuleContext, m types.RuleMsg, e error, r string) {
+		endMsg, rel, runErr = m, r, e
+		close(done)
+	}))
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timeout waiting for chain completion")
+	}
+	return endMsg, rel, runErr
+}
+
+// Initiate 发起人不在目标租户内（identity 实现 TenantMembershipChecker 时）：拒绝且不落发起调用。
+func TestStartProcessNode_InitiatorNotInTenant(t *testing.T) {
+	fake := registerStartProcessForTest(t)
+	spTestIdentity.deny("u_foreign")
+	defer spTestIdentity.reset()
+
+	engine := buildStartProcessEngine(t, "t_sp_not_in_tenant",
+		`{"processKey":"leave","initiator":"u_foreign"}`)
+	msg := tenantMsg(`{}`)
+
+	_, rel, err := runChain(t, engine, msg)
+	assert.Equal(t, types.Failure, rel)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not in tenant")
+	assert.Empty(t, fake.calls())
+}
+
+// metadata 声称的租户与 ctx 内真实操作人租户不一致：拒绝（metadata 不可越租户发起）。
+func TestStartProcessNode_ActorTenantMismatch(t *testing.T) {
+	fake := registerStartProcessForTest(t)
+
+	engine := buildStartProcessEngine(t, "t_sp_tenant_mismatch",
+		`{"processKey":"leave","initiator":"u_001"}`)
+	actorCtx := service.SetUserToCtx(context.Background(),
+		&service.Actor{UserID: "u_001", TenantID: "tenant_x"})
+	msg := tenantMsg(`{}`) // metadata = tenant_a
+
+	_, rel, err := runStartProcessChainWithCtx(t, engine, msg, actorCtx)
+	assert.Equal(t, types.Failure, rel)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "mismatches")
+	assert.Empty(t, fake.calls())
+}
+
+// ctx 内真实操作人租户优先：metadata 无 tenant_id 时从 actor 推导（不报"缺租户"）。
+func TestStartProcessNode_TenantFromActorCtx(t *testing.T) {
+	fake := registerStartProcessForTest(t)
+
+	engine := buildStartProcessEngine(t, "t_sp_tenant_from_actor",
+		`{"processKey":"leave","initiator":"u_001"}`)
+	actorCtx := service.SetUserToCtx(context.Background(),
+		&service.Actor{UserID: "u_001", TenantID: "tenant_x"})
+	msg := types.NewMsgWithJsonData(`{}`) // 无 tenant_id
+
+	_, rel, err := runStartProcessChainWithCtx(t, engine, msg, actorCtx)
+	require.NoError(t, err)
+	assert.Equal(t, types.Success, rel)
+
+	calls := fake.calls()
+	require.Len(t, calls, 1)
+	actor := calls[0]["actor"].(service.Actor)
+	assert.Equal(t, "tenant_x", actor.TenantID)
+	assert.Equal(t, "u_001", actor.UserID)
 }

--- a/components/tenant_checker_test.go
+++ b/components/tenant_checker_test.go
@@ -1,0 +1,40 @@
+package components
+
+import (
+	"context"
+	"sync"
+
+	"github.com/rulego/gflow-engine/service"
+)
+
+// fakeTenantChecker 测试用身份源：仅实现 TenantMembershipChecker，其余 IdentityService
+// 方法经 nil 嵌入接口占位（被测路径只走 IsUserInTenant）。默认所有用户"在租户内"，
+// 可用 deny 标为跨租户、reset 清空。
+type fakeTenantChecker struct {
+	service.IdentityService
+	mu          sync.Mutex
+	notInTenant map[string]bool
+}
+
+func (f *fakeTenantChecker) IsUserInTenant(_ context.Context, _ string, userID string) (bool, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return !f.notInTenant[userID], nil
+}
+
+func (f *fakeTenantChecker) deny(userIDs ...string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.notInTenant == nil {
+		f.notInTenant = map[string]bool{}
+	}
+	for _, id := range userIDs {
+		f.notInTenant[id] = true
+	}
+}
+
+func (f *fakeTenantChecker) reset() {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.notInTenant = nil
+}

--- a/service/identity_service.go
+++ b/service/identity_service.go
@@ -2,8 +2,10 @@ package service
 
 import (
 	"context"
-	"github.com/rulego/gflow-engine/types/constants"
+	"fmt"
 	"time"
+
+	"github.com/rulego/gflow-engine/types/constants"
 )
 
 // User 用户实体
@@ -139,6 +141,34 @@ type IdentityService interface {
 type TenantMembershipChecker interface {
 	// IsUserInTenant 判断用户是否属于指定租户
 	IsUserInTenant(ctx context.Context, tenantID string, userID string) (bool, error)
+}
+
+// EnsureUserInTenant 校验 userID 属于 tenantID。宿主注入的 IdentityService 若同时实现
+// 可选接口 TenantMembershipChecker 则执行真实校验：不在租户内返回 ErrPermissionDenied，
+// 查询失败返回原始错误（fail-closed）。
+//
+// identity 为 nil、或未实现 TenantMembershipChecker 时返回 nil——引擎自身不含用户目录，
+// 无法判定；信任边界调用方（startProcess 发起、ccTask 自选抄送）应在未实现时自行权衡
+// 是否 fail-closed（本引擎对该类场景默认放行并告警，与转办/委派目标校验口径一致）。
+func EnsureUserInTenant(ctx context.Context, identity IdentityService, tenantID, userID string) error {
+	if identity == nil {
+		return nil
+	}
+	checker, ok := identity.(TenantMembershipChecker)
+	if !ok {
+		return nil
+	}
+	if userID == "" {
+		return fmt.Errorf("empty user id: %w", ErrValidation)
+	}
+	inTenant, err := checker.IsUserInTenant(ctx, tenantID, userID)
+	if err != nil {
+		return fmt.Errorf("failed to check user %q in tenant %q: %w", userID, tenantID, err)
+	}
+	if !inTenant {
+		return fmt.Errorf("user %q is not a member of tenant %q: %w", userID, tenantID, ErrPermissionDenied)
+	}
+	return nil
 }
 
 // GetUserFromCtx 从 ctx 取出 bindActor 绑定的操作人（*Actor）；未绑定返回 nil。

--- a/service/identity_service_membership_test.go
+++ b/service/identity_service_membership_test.go
@@ -1,0 +1,60 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+// membershipIdentity 仅实现 TenantMembershipChecker 的测试身份源：sqrt 其余
+// IdentityService 方法经 nil 嵌入接口占位（EnsureUserInTenant 只会走 IsUserInTenant）。
+type membershipIdentity struct {
+	IdentityService
+	inTenant bool
+	err      error
+}
+
+func (m *membershipIdentity) IsUserInTenant(_ context.Context, _ string, _ string) (bool, error) {
+	return m.inTenant, m.err
+}
+
+func TestEnsureUserInTenant(t *testing.T) {
+	ctx := context.Background()
+
+	// identity 为 nil：引擎无用户目录，跳过校验（不报错）
+	if err := EnsureUserInTenant(ctx, nil, "t1", "u1"); err != nil {
+		t.Fatalf("nil identity should skip check, got %v", err)
+	}
+
+	// IdentityService 未实现 TenantMembershipChecker：跳过校验（不报错）
+	if err := EnsureUserInTenant(ctx, &IdentityServiceImpl{}, "t1", "u1"); err != nil {
+		t.Fatalf("non-checker identity should skip check, got %v", err)
+	}
+
+	// 空 userID：直接校验失败，不触发 SPI 调用
+	if err := EnsureUserInTenant(ctx, &membershipIdentity{inTenant: true}, "t1", ""); err == nil {
+		t.Fatal("empty userID should fail validation")
+	} else if !errors.Is(err, ErrValidation) {
+		t.Fatalf("empty userID should be ErrValidation, got %v", err)
+	}
+
+	// 在租户内：通过
+	if err := EnsureUserInTenant(ctx, &membershipIdentity{inTenant: true}, "t1", "u1"); err != nil {
+		t.Fatalf("in-tenant user should pass, got %v", err)
+	}
+
+	// 不在租户内：ErrPermissionDenied
+	if err := EnsureUserInTenant(ctx, &membershipIdentity{inTenant: false}, "t1", "u1"); err == nil {
+		t.Fatal("out-of-tenant user should fail")
+	} else if !errors.Is(err, ErrPermissionDenied) {
+		t.Fatalf("out-of-tenant user should be ErrPermissionDenied, got %v", err)
+	}
+
+	// checker 查询错误：原样透传（fail-closed）
+	checkErr := errors.New("identity backend unavailable")
+	if err := EnsureUserInTenant(ctx, &membershipIdentity{err: checkErr}, "t1", "u1"); err == nil {
+		t.Fatal("checker error should propagate")
+	} else if !errors.Is(err, checkErr) {
+		t.Fatalf("checker error should wrap original, got %v", err)
+	}
+}

--- a/service/runtime_subprocess.go
+++ b/service/runtime_subprocess.go
@@ -31,8 +31,14 @@ func (s *RuntimeServiceImpl) StartSubProcessInstance(ctx context.Context, parent
 	if childDef == nil {
 		return "", fmt.Errorf("%w: child process def %s", ErrNotFound, childProcessDefID)
 	}
-	// CreatedBy 现存储发起人用户 ID（见 startInstanceCore 注释），子流程发起人沿用父实例身份。
-	initiator := Actor{UserID: parent.StartUserID, UserName: parent.CreatedBy, TenantID: parent.TenantID}
+	// 防御性租户比对：子流程定义必须与父实例同租户，阻断跨租户子流程注入。
+	if childDef.TenantID != parent.TenantID {
+		return "", fmt.Errorf("subProcess child def %s belongs to tenant %q, parent tenant %q: %w",
+			childProcessDefID, childDef.TenantID, parent.TenantID, ErrPermissionDenied)
+	}
+	// CreatedBy/StartUserID 现均存发起人"用户 ID"（见 startInstanceCore 注释），父实例并不保存
+	// 展示名；子流程发起人只继承用户 ID，UserName 留空由展示层按 ID 批量查名。
+	initiator := Actor{UserID: parent.StartUserID, TenantID: parent.TenantID}
 	// 子流程继承父流程业务变量:subProcess 节点目前传 nil variables,子实例会丢失父数据,
 	// 子链内的条件节点拿不到父变量。调用方未显式传变量时,从父实例 variables(启动业务变量)
 	// 加载,让子链能读到父数据。


### PR DESCRIPTION
🤖 人工智能辅助贡献  
使用的工具：Deepseek Harness / deepseek v4 pro
参与程度：全部变更代码。所有代码均已人工审核并通过验证。

---

## 背景

审计发现四处信任边界漏洞，均源于「引擎把消息里可被调用方篡改的字段当作身份/租户的信任根」：

- **高危** `startProcess` 发起节点的 `initiator` 来自 `${msg.xxx}` 模板、`tenant_id` 来自消息 metadata，均未校验。可把发起人设为任意用户（污染 `start_user_id/created_by`，影响 `direct_manager/initiator_self` 审批路由），并注入任意 `tenant_id` 越租户发起。
- **低危** 子流程启动未校验 `childDef.TenantID == parent.TenantID`，存在跨租户子流程注入面。
- **低危** 子流程 `Actor.UserName` 填入 `parent.CreatedBy`（实为用户 ID），与 `startInstanceCore` 中「CreatedBy 存用户 ID」的语义自相矛盾。
- **低危** `ccTask` 自选抄送人直接取业务变量 `ccUserIds`，未做租户归属校验，可越租户抄送。

## 变更

**1. 新增 `service.EnsureUserInTenant(ctx, identity, tenantID, userID) error`（`service/identity_service.go`）**

统一的租户归属校验谓词：宿主 identity 若实现可选接口 `TenantMembershipChecker` 则执行真实校验——不在租户内返回 `ErrPermissionDenied`，查询失败原样透传（fail-closed）；identity 为 nil 或未实现该接口时返回 nil（引擎自身不含用户目录），与现有转办/委派目标校验口径一致。

**2. H2 — startProcess 发起节点（`components/start_process_node.go`）**

- 发起前经 `EnsureUserInTenant` 校验 `initiator ∈ tenantID`，阻断「以任意用户身份/任意租户」发起。
- 真实用户上下文下，租户以 ctx 内绑定的操作人为信任根：`metadata.tenant_id` 与操作人租户不一致即拒绝；仅系统/无操作人上下文（定时链、编辑器手动测试）才回退 metadata 静态租户。
- 节点新增 `IdentityService` 字段，在 `Register` 注入并在 `New` 透传。

**3. L3 — 子流程跨租户注入（`service/runtime_subprocess.go`）**

`StartSubProcessInstance` 取到 `childDef` 后校验其租户与父实例一致，不一致返回 `ErrPermissionDenied`。

**4. L7 — 子流程发起人姓名字段（同文件）**

移除 `UserName: parent.CreatedBy`（不再把用户 ID 塞进姓名字段）；`UserName` 留空，由展示层按用户 ID 批量查显示名，与 `startInstanceCore` 注释语义对齐。

**5. L9 — ccTask 抄送越租户（`components/cc_task_node.go`）**

抄送循环内对每个 userId 执行 `EnsureUserInTenant`，跨租户 userId 被过滤、计入失败数（沿用「至少一个成功即推进」的非阻塞语义）；节点新增并注入 `IdentityService`。

**6. 接线（`components/register.go`）**

给 `StartProcessNode` / `CCTaskNode` 原型注入 `IdentityService`。

## 测试

- `service/identity_service_membership_test.go`（新增）：`EnsureUserInTenant` 全分支——nil 跳过、无 checker 跳过、空 userID 校验失败、在租户通过、越租户 `ErrPermissionDenied`、checker 错误透传。
- `components/start_process_node_test.go`：新增 `InitiatorNotInTenant`、`ActorTenantMismatch`、`TenantFromActorCtx`。
- `components/cc_task_node_test.go`：新增 `SelfSelectFiltersCrossTenant`。
- `components/tenant_checker_test.go`（新增）：共享的测试用 `TenantMembershipChecker` 身份源。

## 验证

- `gofmt` / `go vet ./...` / `go test ./...`（含 `test/e2e`）全部通过（SQLite 内存库，无外部依赖）。