### PR TITLE
fix: 修复本地键锁陈旧有效期与锁凭证熵错误

### DIFF
--- a/utils/lock/key_lock.go
+++ b/utils/lock/key_lock.go
@@ -99,43 +99,50 @@ func (l *LocalLock) Close() {
 
 // Lock 获取本地锁
 func (l *LocalLock) Lock(ctx context.Context, key string, expiration time.Duration) (string, error) {
-	value := generateLockValue()
-	expiredAt := time.Now().Add(expiration)
+	value, err := generateLockValue()
+	if err != nil {
+		return "", err
+	}
 
 	for {
-		if actual, loaded := l.locks.LoadOrStore(key, &lockInfo{
+		// expiredAt 必须每轮重试都重新计算（紧贴 LoadOrStore）：
+		//   - 等待期间消耗的时间不应从新锁有效期里扣；
+		//   - 用循环外只算一次的陈旧 expiredAt 装进 LoadOrStore，会让等久才抢到锁的
+		//     持有者拿到"已过期"的锁，被随后的 CAS 立即抢占 → 两个 goroutine 同时进临界区。
+		expiredAt := time.Now().Add(expiration)
+		actual, loaded := l.locks.LoadOrStore(key, &lockInfo{
 			value:     value,
 			expiredAt: expiredAt,
-		}); !loaded {
+		})
+		if !loaded {
 			// 成功获取锁
 			return value, nil
-		} else {
-			// 锁已存在，检查是否过期
-			info := actual.(*lockInfo)
-			info.mutex.RLock()
-			expired := time.Now().After(info.expiredAt)
-			info.mutex.RUnlock()
+		}
+		// 锁已存在，检查是否过期
+		info := actual.(*lockInfo)
+		info.mutex.RLock()
+		expired := time.Now().After(info.expiredAt)
+		info.mutex.RUnlock()
 
-			if expired {
-				// 锁已过期：CAS 直接换成新锁。不能换成 nil——并发 Lock
-				// 会 LoadOrStore 到 nil 并在类型断言处 panic。
-				// expiredAt 重新计算：等待期间消耗的时间不应从新锁有效期里扣。
-				if l.locks.CompareAndSwap(key, info, &lockInfo{
-					value:     value,
-					expiredAt: time.Now().Add(expiration),
-				}) {
-					return value, nil
-				}
-				continue
+		if expired {
+			// 锁已过期：CAS 直接换成新锁。不能换成 nil——并发 Lock
+			// 会 LoadOrStore 到 nil 并在类型断言处 panic。
+			// 用本轮回合刚算出的 expiredAt（见上），不另算也不复用陈旧值。
+			if l.locks.CompareAndSwap(key, info, &lockInfo{
+				value:     value,
+				expiredAt: expiredAt,
+			}) {
+				return value, nil
 			}
+			continue
+		}
 
-			// 锁未过期，等待一段时间后重试
-			select {
-			case <-ctx.Done():
-				return "", ctx.Err()
-			case <-time.After(10 * time.Millisecond):
-				continue
-			}
+		// 锁未过期，等待一段时间后重试
+		select {
+		case <-ctx.Done():
+			return "", ctx.Err()
+		case <-time.After(10 * time.Millisecond):
+			continue
 		}
 	}
 }
@@ -160,7 +167,10 @@ func (l *LocalLock) Unlock(ctx context.Context, key, value string) error {
 
 // TryLock 尝试获取本地锁（非阻塞）
 func (l *LocalLock) TryLock(ctx context.Context, key string, expiration time.Duration) (string, bool, error) {
-	value := generateLockValue()
+	value, err := generateLockValue()
+	if err != nil {
+		return "", false, err
+	}
 	expiredAt := time.Now().Add(expiration)
 
 	if actual, loaded := l.locks.LoadOrStore(key, &lockInfo{
@@ -243,11 +253,15 @@ func (l *LocalLock) cleanupExpiredLocks() {
 	}
 }
 
-// generateLockValue 生成锁的值
-func generateLockValue() string {
+// generateLockValue 生成锁的持有凭证值（随机 16 字节 → 32 位 hex）。
+// crypto/rand 失败意味着系统熵源异常、无法生成安全凭证——必须向上抛出而非静默返回
+// 确定性或全零值（否则所有持有者可能拿到相同 value，Unlock 的凭证校验随之失效）。
+func generateLockValue() (string, error) {
 	bytes := make([]byte, 16)
-	rand.Read(bytes)
-	return hex.EncodeToString(bytes)
+	if _, err := rand.Read(bytes); err != nil {
+		return "", fmt.Errorf("generate lock value: %w", err)
+	}
+	return hex.EncodeToString(bytes), nil
 }
 
 // DefaultKeyLock 默认键锁实例（本地模式）

--- a/utils/lock/key_lock_test.go
+++ b/utils/lock/key_lock_test.go
@@ -2,6 +2,7 @@ package lock
 
 import (
 	"context"
+	"encoding/hex"
 	"testing"
 	"time"
 )
@@ -174,5 +175,83 @@ func TestLocalLock_DifferentKeys(t *testing.T) {
 func TestDefaultKeyLockIsNotNil(t *testing.T) {
 	if DefaultKeyLock == nil {
 		t.Error("DefaultKeyLock should not be nil")
+	}
+}
+
+// 回归（H3）：等待者 B 在持有者 A 正常释放后抢到的锁，必须带"未来"有效期。
+// 修复前 expiredAt 在循环外只算一次，B 等久后把已过期的陈旧值装进 LoadOrStore，
+// 导致锁即刻被判过期、被 CAS 抢占 → 两个 goroutine 同时进临界区。
+func TestLocalLock_LockAfterWaitUsesFreshExpiry(t *testing.T) {
+	l := NewLocalLock()
+	ctx := context.Background()
+
+	// 持有者 A：长有效期，靠 Unlock 正常释放（而非自然过期）。
+	vA, err := l.Lock(ctx, "stale-expiry", time.Hour)
+	if err != nil {
+		t.Fatalf("holder lock failed: %v", err)
+	}
+
+	// 等待者 B：短有效期。B 抢锁时的 expiredAt 取决于是"入口时刻"还是"抢占时刻"。
+	const shortTTL = 40 * time.Millisecond
+	type result struct {
+		value string
+		err   error
+	}
+	acquired := make(chan result, 1)
+	go func() {
+		vB, err := l.Lock(ctx, "stale-expiry", shortTTL)
+		acquired <- result{vB, err}
+	}()
+
+	// 让 B 等待超过 shortTTL，使"入口时刻"算出的 expiredAt 成为过去时。
+	time.Sleep(80 * time.Millisecond)
+
+	// A 正常释放（CompareAndDelete），B 的下一次 LoadOrStore 会装上自己的锁。
+	if err := l.Unlock(ctx, "stale-expiry", vA); err != nil {
+		t.Fatalf("holder unlock failed: %v", err)
+	}
+
+	var got result
+	select {
+	case got = <-acquired:
+	case <-time.After(2 * time.Second):
+		t.Fatal("waiter did not acquire after holder release")
+	}
+	if got.err != nil {
+		t.Fatalf("waiter lock failed: %v", got.err)
+	}
+	if got.value == "" {
+		t.Fatal("waiter lock returned empty value")
+	}
+
+	// 关键断言：B 刚抢到锁，锁必须仍未过期，TryLock 必须失败。
+	// 若 B 用陈旧 expiredAt 装锁，锁即刻过期，TryLock 会 CAS 抢占成功（双持有者）。
+	_, ok, err := l.TryLock(ctx, "stale-expiry", time.Hour)
+	if err != nil {
+		t.Fatalf("tryLock failed: %v", err)
+	}
+	if ok {
+		t.Fatal("freshly acquired lock is immediately expired (second holder acquired)")
+	}
+}
+
+func TestGenerateLockValue(t *testing.T) {
+	v1, err := generateLockValue()
+	if err != nil {
+		t.Fatalf("generateLockValue failed: %v", err)
+	}
+	if len(v1) != 32 {
+		t.Fatalf("expected 32-char hex value, got len=%d (%q)", len(v1), v1)
+	}
+	if _, err := hex.DecodeString(v1); err != nil {
+		t.Fatalf("expected hex-encoded value: %v", err)
+	}
+
+	v2, err := generateLockValue()
+	if err != nil {
+		t.Fatalf("second generateLockValue failed: %v", err)
+	}
+	if v1 == v2 {
+		t.Error("two generated values should differ")
 	}
 }


### PR DESCRIPTION
🤖 人工智能辅助贡献  
使用的工具：Deepseek Harness / deepseek v4 pro
参与程度：全部变更代码。所有代码均已人工审核并通过验证。

---

## 背景

`utils/lock/key_lock.go` 进程内键锁存在两处缺陷：

- **H3（高危）** `LocalLock.Lock` 的 `expiredAt` 在循环外只算一次，`LoadOrStore` 每轮复用这一陈旧值。等待者在上一个持有者**正常释放**（`CompareAndDelete`）后，下一次 `LoadOrStore` 装上的 `expiredAt` 可能早已过去 → 新持有者即刻被判过期、被并发的 CAS 抢占，两个 goroutine 同时进入临界区。
- **L10（低危）** `generateLockValue` 忽略 `crypto/rand.Read` 的错误。熵源异常时静默返回全零/确定性 value，所有持有者可能拿到相同凭证，`Unlock` 的 value 校验随之失效。

## 变更

**1. H3 — `LocalLock.Lock`（`utils/lock/key_lock.go`）**

- `expiredAt` 从循环外移入循环内，每轮重试都紧贴 `LoadOrStore` 重新计算：
  - 等待期间消耗的时间不再从新锁有效期里扣；
  - `LoadOrStore` 与过期 CAS 分支复用的都是本轮回合新算出的值，杜绝陈旧 `expiredAt` 装进锁。
- 顺带把原先的 `if…else…` 嵌套拍平为早返回结构，行为不变。

**2. L10 — `generateLockValue`（同文件）**

- 签名由 `string` 改为 `(string, error)`：`rand.Read` 失败时向上抛出 `fmt.Errorf("generate lock value: %w", err)`，不再静默吞错；
- `Lock` / `TryLock` 两个调用点同步处理该错误（`Lock` 返回 `("", err)`；`TryLock` 返回 `("", false, err)`）。

## 测试

- `TestLocalLock_LockAfterWaitUsesFreshExpiry`（新增回归）：持有者 A 用长有效期、靠 `Unlock` 正常释放；等待者 B 用短有效期且等待时间超过该有效期后抢锁，断言 B 抢到后 `TryLock` 必须失败（锁仍带"未来"有效期）。该用例在修复前可稳定触发"双持有者"，修复后通过。
- `TestGenerateLockValue`（新增）：返回值无错误、为 32 位 hex 且两次生成互不相同。
- 全量 `go test ./...`（含 `test/e2e`）通过，`utils/lock` 用 `-race` 通过。